### PR TITLE
Feature/more managed grants

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,34 +234,59 @@ which we will discuss here. A simplified overview of the idea is in this figure:
 
 ![grupr access management model](grupr_access_management_model.svg)
 
-For each combination of data product and dtap, grupr creates a read role, and a
-write role. Employees working on this data product can assume the read role.
-The write role is intended for service accounts to assume.
+We see two products. In reality, when we deploy software, we do this in a dtap.  And grupr can manage different dtaps in
+a single YAML description, as you have already seen. So, in the grupr code, we call the products in the above diagram
+`ProductDTAP`s. Below, when we write "product" we are often referring to a product dtap combination. When we leave out
+the "dtap" part, you can assume that we are talking about a production environment only. Grupr does allow different
+products to define a different set of dtaps in the YAML, and some cross dtap relationships are allowed. In such cases,
+the documentation will be more explicit.
 
-A quick note--below, when we write "product" we are often referring to a
-"product-dtap" combination, actually, for simplicity we often leave out the
-"dtap" part, you can assume that we are talking about a production environment
-only. That being said, grupr does allow different products to have a different
-set of dtaps, and some cross dtap relationships are allowed. In such cases, the
-documentation will be more explicit.
+For each combination of data product and dtap, grupr creates a read role, and a write role. Employees working on this
+data product can assume the read role.  The write role is intended for service accounts to assume.
 
-Products and interfaces are a collection of objects, e.g., tables and views.
-Products do not overlap. Interfaces are subsets of products. But interfaces
-can overlap. In the figure above, product B consumes interface 1 of product A.
+Products and interfaces are a collection of objects, e.g., tables and views.  Products do not overlap. Interfaces are
+subsets of products. But interfaces can overlap. In the figure above, product B consumes interface 1 of product A.
 
-The read role for product B gets read access to all objects in product B, as
-well as read access to all objects in interface A1 consumed by the product;
-this is why interface A1 and product B are shown in bold. The write role for
-product B gets write access to all objects in product B, but only read access
-to all objects in interface A1. Note that it is accepted in grupr YAML for a
-non-production product-dtap to consume a production interface--but not the
-other way around.
+The read role for product B gets read access to all objects in product B, as well as read access to all objects in
+interface A1 consumed by the product; this is why interface A1 and product B are shown in bold. The write role for
+product B gets write access to all objects in product B, but only read access to all objects in interface A1. Note that
+it is accepted in grupr YAML for a non-production product-dtap to consume a production interface--but not the other way
+around.
 
-Rather than directly getting privileges on the objects,for efficiency reasons
-(fewer relations to manage) read privileges to objects are granted to database
-roles. Each product and each interface has a set of associated database roles.
-Usually this set will have just one database role, but there can be more if
-objects of a sinlge product or interface reside in different databases.
+Rather than directly getting privileges on the objects,for efficiency reasons (fewer relations to manage) read
+privileges to objects are granted to database roles. Each product and each interface has a set of associated database
+roles.  Usually this set will have just one database role, but there can be more if objects of a sinlge product or
+interface reside in different databases.
+
+Grupr manages the following privileges for the product-dtap read role:
+|  Object types | Privileges |
+| --- | --- |
+|  Database role (grupr managed) | Usage |
+|  Warehouse     | Usage, Operate |
+
+This means that grupr will decide based on the YAML which grupr-owned database roles a product read role will be
+granted. If you manually grant a different grupr-owned database role to the product role, grupr will revoke it.
+But if you manually grant a database role that you created without using grupr, grupr will not revoke it.
+For warehouses, grupr will decide based on the YAML which warehouses a product role may use.
+
+For the product-dtap write role, grupr manages:
+|  Object types | Privileges |
+| --- | --- |
+|  Database role (grupr managed) | Usage |
+|  Warehouse     | Usage, Operate |
+|  Table, Hybrid table, View, Materialized View | Ownership |
+
+This means that for the listed object types, grupr will decide based on your YAML which objects the product
+write role will claim ownership of. It also means that if you grant ownership on another object of the
+managed object types to the product write role, grupr will attempt to transfer that ownership away from the product
+write role again. But if you grant ownership on an object type that grupr does not yet manage, for example
+a dynamic table, then that is not a grant grupr normally manages, and it will leave it intact. Also, note
+that privileges like update, insert, etc, are also not managed. You can grant such privileges to the product
+write role, and grupr will not revoke them. Granting that on objects on which grupr already claims ownership
+would just be redundant, of course. But you might want the product write role to be able to update a table
+outside of its own product, perhaps if you want to write some operational metadata in a common table, or
+whatever. Such grants will not be revoked by grupr.
+
 
 Concretely then, the product read role is granted the database roles of the product
 objects, and the database roles of all interface it consumes. If you want

--- a/README.md
+++ b/README.md
@@ -264,7 +264,15 @@ Usually this set will have just one database role, but there can be more if
 objects of a sinlge product or interface reside in different databases.
 
 Concretely then, the product read role is granted the database roles of the product
-objects, and the database roles of all interface it consumes.
+objects, and the database roles of all interface it consumes. If you want
+to grant read privileges to objects of types that grupr does not yet manage,
+you can do so. Grupr will leave these grants intact, and as long as any remain,
+it will also keep the USAGE privilege on the containing schemas intact. If you insist,
+it is also possible to grant such privileges directly to the product read role,
+but if you make that choice, you have to also grant USAGE on the containing schemas
+and databases to the product write role directly; being privileges that grupr
+normally does not manage for a product read role, it would leave such grants intact
+as well.
 
 The product write role also gets granted the same database roles. But on top of
 that, the write role gets the ownership privilege on all objects in the product
@@ -275,6 +283,11 @@ current owner retains ownership of the object. After running grupr, you can
 update your production deployments to assume the product write role when
 connecting to Snowflake. When you are sure everything runs smoothly, you can
 revoke the product write role from the role that previously owned the object.
+
+If you grant privileges directly to the write role that grupr does not normally manage; or privileges on object types that grupr
+does not normally manage; then you should also grant USAGE on the containing schemas and databases directly to the write
+role. Not doing so means you will rely on managed privileges to still exist based on the YAML in those same schemas and
+databases.
 
 If you change the YAML, it can be that privileges that have been granted in the
 database, based on an earlier YAML version, need to be revoked, and grupr will

--- a/README.md
+++ b/README.md
@@ -261,18 +261,22 @@ interface reside in different databases.
 Grupr manages the following privileges for the product-dtap read role:
 |  Object types | Privileges |
 | --- | --- |
-|  Database role (grupr managed) | Usage |
+|  Database role (grupr-managed) | Usage |
 |  Warehouse     | Usage, Operate |
 
 This means that grupr will decide based on the YAML which grupr-owned database roles a product read role will be
 granted. If you manually grant a different grupr-owned database role to the product role, grupr will revoke it.
-But if you manually grant a database role that you created without using grupr, grupr will not revoke it.
+But if you manually grant a database role that you created without using grupr, grupr will not revoke it. For 
+example, it is encouraged to grant database roles of imported databases to the product-dtap read roles. Grupr
+will not touch them. Even if, contrary to Snowflake best practices, you grant IMPORTED PRIVILEGES to a product
+read role, and the product read role consequently has SELECT privileges on many objects, grupr will not revoke
+them; from the perspective of a product read role, SELECT is an unmanaged privilege.
 For warehouses, grupr will decide based on the YAML which warehouses a product role may use.
 
 For the product-dtap write role, grupr manages:
 |  Object types | Privileges |
 | --- | --- |
-|  Database role (grupr managed) | Usage |
+|  Database role (grupr-managed) | Usage |
 |  Warehouse     | Usage, Operate |
 |  Table, Hybrid table, View, Materialized View | Ownership |
 
@@ -287,27 +291,20 @@ would just be redundant, of course. But you might want the product write role to
 outside of its own product, perhaps if you want to write some operational metadata in a common table, or
 whatever. Such grants will not be revoked by grupr.
 
+Concretely then, the product read role is granted the database roles of the product objects, and the database roles of
+all interface it consumes. If you want to grant read privileges to objects of types that grupr does not yet manage, you
+can do so. Grupr will leave these grants intact, and as long as any remain, it will also keep the USAGE privilege on the
+containing schemas intact. If you insist, it is also possible to grant such privileges directly to the product read
+role, but if you make that choice, you have to also grant USAGE on the containing schemas and databases to the product
+write role directly; being privileges that grupr normally does not manage for a product read role, it would leave such
+grants intact as well.
 
-Concretely then, the product read role is granted the database roles of the product
-objects, and the database roles of all interface it consumes. If you want
-to grant read privileges to objects of types that grupr does not yet manage,
-you can do so. Grupr will leave these grants intact, and as long as any remain,
-it will also keep the USAGE privilege on the containing schemas intact. If you insist,
-it is also possible to grant such privileges directly to the product read role,
-but if you make that choice, you have to also grant USAGE on the containing schemas
-and databases to the product write role directly; being privileges that grupr
-normally does not manage for a product read role, it would leave such grants intact
-as well.
-
-The product write role also gets granted the same database roles. But on top of
-that, the write role gets the ownership privilege on all objects in the product
-dtap. This privilege is granted directly to the write role, not via database
-roles.  Before granting ownership of an object to a product write role, the
-product write role itself is granted to the current owner. This way, the
-current owner retains ownership of the object. After running grupr, you can
-update your production deployments to assume the product write role when
-connecting to Snowflake. When you are sure everything runs smoothly, you can
-revoke the product write role from the role that previously owned the object.
+The product write role also gets granted the same database roles. But on top of that, the write role gets the ownership
+privilege on all objects in the product dtap. This privilege is granted directly to the write role, not via database
+roles.  Before granting ownership of an object to a product write role, the product write role itself is granted to the
+current owner. This way, the current owner retains ownership of the object. After running grupr, you can update your
+production deployments to assume the product write role when connecting to Snowflake. When you are sure everything runs
+smoothly, you can revoke the product write role from the role that previously owned the object.
 
 If you grant privileges directly to the write role that grupr does not normally manage; or privileges on object types that grupr
 does not normally manage; then you should also grant USAGE on the containing schemas and databases directly to the write
@@ -326,7 +323,7 @@ with a configurable prefix) but that are not found in the YAML will be removed.
 However, if such roles have privileges that are outside of grupr its scope, 
 and therefore must have been granted outside of grupr, grupr logs a message but
 keeps the role and those additional privileges intact. If a product write role
-needs to be removed, but still ownis an object, grupr will transfer
+needs to be removed, but still owns an object, grupr will transfer
 ownership back to SYSADMIN if the product write role is not currently granted
 to any user managed role. If the product write role is granted to one user managed role, 
 that user managed role will get ownership. If the product write role is granted

--- a/cmd/grupr/grupr.go
+++ b/cmd/grupr/grupr.go
@@ -21,7 +21,7 @@ func main() {
 	yamlPath := flag.Arg(0)
 	var snowflakeYamlPath string
 	if len(flag.Args()) == 2 {
-		snowflakeYamlPath = flag.Arg(1)	
+		snowflakeYamlPath = flag.Arg(1)
 	}
 
 	// TODO: while deserializing into Grupin, also gunzip, and

--- a/internal/snowflake/account_cache.go
+++ b/internal/snowflake/account_cache.go
@@ -108,7 +108,7 @@ func (c *accountCache) matchSchemas(ctx context.Context, conn *sql.DB, db semant
 }
 
 func (c *accountCache) matchObjects(ctx context.Context, conn *sql.DB, db semantics.Ident, schema semantics.Ident, om semantics.ObjMatcher,
-	map[ObjType]bool mots, o *matchedSchemaObjs) error {
+	mots map[ObjType]bool, o *matchedSchemaObjs) error {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	if !c.hasDB(db) {

--- a/internal/snowflake/account_cache.go
+++ b/internal/snowflake/account_cache.go
@@ -20,12 +20,13 @@ type accountCache struct {
 	dbExists map[semantics.Ident]bool
 }
 
-func newAccountCache(ctx context.Context, semCnf *semantics.Config, cnf *Config, conn *sql.DB) (c *accountCache, err error) {
+func newAccountCache(ctx context.Context, semCnf *semantics.Config, cnf *Config, conn *sql.DB,
+	managedDBs map[semantics.Ident]bool) (c *accountCache, err error) {
 	c = &accountCache{}
 	// We initialize at least the databases before we start.
 	// That way, even if no object expressions at all are in the YAML, at least we
 	// still have the information which database roles exist (and thus, have to be dropped)
-	err = c.refreshDBs(ctx, semCnf, cnf, conn)
+	err = c.refreshDBs(ctx, semCnf, cnf, conn, managedDBs)
 	return
 }
 
@@ -55,7 +56,7 @@ func (c *accountCache) matchDBs(ctx context.Context, semCnf *semantics.Config, c
 	defer c.mu.Unlock()
 	if o.version == c.version {
 		// cache entry is stale
-		if err := c.refreshDBs(ctx, semCnf, cnf, conn); err != nil {
+		if err := c.refreshDBs(ctx, semCnf, cnf, conn, nil); err != nil {
 			return err
 		}
 	}
@@ -138,7 +139,11 @@ func (c *accountCache) matchObjects(ctx context.Context, conn *sql.DB, db semant
 	return nil
 }
 
-func (c *accountCache) refreshDBs(ctx context.Context, semCnf *semantics.Config, cnf *Config, conn *sql.DB) error {
+func (c *accountCache) refreshDBs(ctx context.Context, semCnf *semantics.Config, cnf *Config, conn *sql.DB,
+	managedDBs map[semantics.Ident]bool) error {
+	/*
+		managedDBs has dbs where the grupr role has already been granted CREATE DATABASE ROLE
+	*/
 	dbs, err := queryDBs(ctx, conn)
 	if err != nil {
 		return err
@@ -150,7 +155,7 @@ func (c *accountCache) refreshDBs(ctx context.Context, semCnf *semantics.Config,
 	}
 	for k := range dbs {
 		if !c.hasDB(k) {
-			if err := c.addDB(ctx, semCnf, cnf, conn, k); err != nil {
+			if err := c.addDB(ctx, semCnf, cnf, conn, k, !managedDBs[k]); err != nil {
 				return err
 			}
 		}
@@ -159,7 +164,8 @@ func (c *accountCache) refreshDBs(ctx context.Context, semCnf *semantics.Config,
 	return nil
 }
 
-func (c *accountCache) addDB(ctx context.Context, semCnf *semantics.Config, cnf *Config, conn *sql.DB, k semantics.Ident) error {
+func (c *accountCache) addDB(ctx context.Context, semCnf *semantics.Config, cnf *Config, conn *sql.DB,
+	k semantics.Ident, grantCreateDBRole bool) error {
 	if c.dbs == nil {
 		c.dbs = map[semantics.Ident]*dbCache{}
 		c.dbExists = map[semantics.Ident]bool{}
@@ -170,7 +176,7 @@ func (c *accountCache) addDB(ctx context.Context, semCnf *semantics.Config, cnf 
 	// After a DB has been dropped and recreated, DB roles may have been dropped;
 	// Also, the privilege CREATE DATABASE ROLE that the grupr role should have may have been revoked.
 	// But, if this is the first time the DB was added, those things may be in place.
-	if err := c.dbs[k].refreshDBRoles(ctx, semCnf, cnf, conn, k); err != nil {
+	if err := c.dbs[k].refreshDBRoles(ctx, semCnf, cnf, conn, k, grantCreateDBRole); err != nil {
 		return err
 	}
 	c.dbExists[k] = true
@@ -204,7 +210,6 @@ func queryDBs(ctx context.Context, conn *sql.DB) (map[semantics.Ident]struct{}, 
 	dbs := map[semantics.Ident]struct{}{}
 	start := time.Now()
 	log.Printf("Querying Snowflake for database names...\n")
-	// TODO: Develop models (if any) for working with IMPORTED DATABASE, and APPLICATION DATABASE
 	// TODO: When there are more than 10K results, paginate
 	rows, err := conn.QueryContext(ctx, `SHOW TERSE DATABASES IN ACCOUNT ->> SELECT "name" FROM $1 WHERE "kind" = 'STANDARD'`)
 	if err != nil {

--- a/internal/snowflake/account_cache.go
+++ b/internal/snowflake/account_cache.go
@@ -41,7 +41,7 @@ func (c *accountCache) match(ctx context.Context, semCnf *semantics.Config, cnf 
 			return err
 		}
 		for schema, schemaObjs := range dbObjs.getSchemas() {
-			err = c.matchObjects(ctx, conn, db, schema, om, schemaObjs)
+			err = c.matchObjects(ctx, conn, db, schema, om, cnf.ManagedObjTypes, schemaObjs)
 			if err != nil {
 				return err
 			}
@@ -107,7 +107,8 @@ func (c *accountCache) matchSchemas(ctx context.Context, conn *sql.DB, db semant
 	return nil
 }
 
-func (c *accountCache) matchObjects(ctx context.Context, conn *sql.DB, db semantics.Ident, schema semantics.Ident, om semantics.ObjMatcher, o *matchedSchemaObjs) error {
+func (c *accountCache) matchObjects(ctx context.Context, conn *sql.DB, db semantics.Ident, schema semantics.Ident, om semantics.ObjMatcher,
+	map[ObjType]bool mots, o *matchedSchemaObjs) error {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	if !c.hasDB(db) {
@@ -122,7 +123,7 @@ func (c *accountCache) matchObjects(ctx context.Context, conn *sql.DB, db semant
 	defer c.dbs[db].schemas[schema].mu.Unlock()
 	if o.version == c.dbs[db].schemas[schema].version {
 		// cache entry is stale
-		if err := c.dbs[db].schemas[schema].refreshObjects(ctx, conn, db, schema); err != nil {
+		if err := c.dbs[db].schemas[schema].refreshObjects(ctx, conn, db, schema, mots); err != nil {
 			return err
 		}
 	}

--- a/internal/snowflake/agg_db_objs.go
+++ b/internal/snowflake/agg_db_objs.go
@@ -16,8 +16,8 @@ type AggDBObjs struct {
 	readDBRole      DatabaseRole
 	isReadDBRoleNew bool // if true, then no need to query grants
 
-	// In / on which schema's does the readDBrole have unmanaged grants?
-	schemasWithUnmanagedGrants map[semantics.Ident]struct{}
+	// Does the DB role have unmanaged privileges?
+	hasUnmanagedGrantsReadDBRole bool
 
 	// Grants to the readDBRole
 	isUsageGrantedOnFutureSchemasToReadDBRole bool
@@ -220,16 +220,21 @@ func (o AggDBObjs) setFutureGrants(ctx context.Context, semCnf *semantics.Config
 func (o AggDBObjs) setGrants(ctx context.Context, semCnf *semantics.Config, cnf *Config, conn *sql.DB, db semantics.Ident, oms semantics.ObjMatchers) (AggDBObjs, error) {
 	if !o.isReadDBRoleNew {
 		// First, check for unmanaged grants, and keep track of in which schemas the database role holds unmanaged grants;
+		// Since we don't know how to parse grants that grupr does not manage, if there is even a single unmanaged
+		// grant, no matter what it is, we are not going to revoke usage or monitor from any databases or schemas; even
+		// if those databases and schemas do not match any object expression from the YAML. After
+		// all, it could be that this would render ineffective an unmanaged privilege on an object in such a schema,
+		// and grupr would break some access that was legitimately put in place by sysadmins.
 		// We should not revoke USAGE on these schemas from the database role, not even if the schema is disjoint from the YAML.
-		o.schemasWithUnmanagedGrants = map[semantics.Ident]struct{}{}
-		for g, err := range QueryGrantsToDBRoleFiltered(ctx, cnf, conn, db, o.readDBRole.Name, nil, cnf.ObjectPrivileges) {
+		//
+		// Note that write privileges on objects are unmanaged from the perspective of a database role. If sysadmins
+		// would grant them to grupr managed database roles, despite best practices, they will have to revoke them also
+		// in case they want grupr to drop the role when it is no longer needed. 
+		for g, err := range QueryGrantsToDBRoleFilteredLimit(ctx, cnf, conn, db, o.readDBRole.Name, nil, cnf.ObjectPrivilegesRead, 1) {
 			if err != nil {
 				return o, err
 			}
-
-			if g.Schema != semantics.Ident("") {
-				o.schemasWithUnmanagedGrants[g.Schema] = struct{}{}
-			}
+			o.hasUnmanagedGrantsReadDBRole = true
 		}
 
 		// Second, check for managed grants
@@ -253,10 +258,7 @@ func (o AggDBObjs) setGrants(ctx context.Context, semCnf *semantics.Config, cnf 
 					continue
 				case ObjTpSchema:
 					if oms.DisjointFromSchema(g.Database, g.Schema) {
-						// Before we revoke schema level privileges, we need to make sure the database role
-						// does not hold any unmanaged grants on objects in the schema; as these would be broken
-						// by the absence of at least one grant on their container: the schema.
-						if _, ok := o.schemasWithUnmanagedGrants[g.Schema]; ok {
+						if o.hasUnmanagedGrantsReadDBRole {
 							// We need to keep this grant
 							continue
 						}
@@ -284,8 +286,6 @@ func (o AggDBObjs) setGrants(ctx context.Context, semCnf *semantics.Config, cnf 
 					// And we need to keep this grant
 					continue
 				}
-			case PrvOwnership:
-				// WIP TODO
 			}
 			// If we are still here, we need to revoke this grant
 			o = o.setRevokeGrantTo(ModeRead, g)

--- a/internal/snowflake/agg_db_objs.go
+++ b/internal/snowflake/agg_db_objs.go
@@ -239,36 +239,56 @@ func (o AggDBObjs) setGrants(ctx context.Context, semCnf *semantics.Config, cnf 
 			}
 
 			if g.Database != db {
-				// This grant should not be granted to this particular database role
-				o = o.setRevokeGrantTo(ModeRead, g)
-				continue
+				// This grant should not be granted to this particular database role, that should not be 
+				// possible in Snowflake, at the moment
+				return o, fmt.Errorf("privilege granted to database role on object from different database")
 			}
 
-			switch g.GrantedOn {
-			case ObjTpSchema:
-				if o.hasSchema(g.Schema) {
-					o.Schemas[g.Schema] = o.Schemas[g.Schema].setGrantTo(ModeRead, g)
-				} else if oms.DisjointFromSchema(g.Database, g.Schema) {
-					// Before we revoke schema level privileges, we need to make sure the database role
-					// does not hold any unmanaged grants on objects in the schema; as these would be broken
-					// by the absence of at least one grant on their container: the schema.
-					if _, ok := o.schemasWithUnmanagedGrants[g.Schema]; !ok {
-						o = o.setRevokeGrantTo(ModeRead, g)
+			switch g.Privileges[0].Privilege {
+			case PrvUsage, Monitor:
+				// At the moment, cnf.ObjectPrivileges has these only on databases and schemas
+				switch g.GrantedOn {
+				case ObjTpDatabase:
+					// We need to keep this grant
+					continue
+				case ObjTpSchema:
+					if oms.DisjointFromSchema(g.Database, g.Schema) {
+						// Before we revoke schema level privileges, we need to make sure the database role
+						// does not hold any unmanaged grants on objects in the schema; as these would be broken
+						// by the absence of at least one grant on their container: the schema.
+						if _, ok := o.schemasWithUnmanagedGrants[g.Schema]; ok {
+							// We need to keep this grant
+							continue
+						}
+						// We need to revoke
+					} else {
+						if o.hasSchema(g.Schema) {
+							o.Schemas[g.Schema] = o.Schemas[g.Schema].setGrantTo(ModeRead, g)
+						}
+						// Either way, if the schema is matched in the YAML, even if it was not there
+						// when we refreshed objects, the grant is fine, we keep it.
+						continue
+					} 
+				}
+			case PrvSelect, PrvReferences, PrvSelectErrorTable:
+				// At the moment, we only have this on ObjTpTable and ObjTpView in cnf.ObjectPrivileges
+				if !oms.DisjointFromObject(g.Database, g.Schema, g.Object) { // else, we need to revoke
+					if o.hasObject(g.Schema, g.Object) {
+						if o.Schemas[g.Schema].Objects[g.Object].ObjectType.String() != g.GrantedOn.String() {
+							// A (hybrid) table may have been dropped and a view with the same name created or vice versa
+							// A good reason to refresh the product
+							return o, ErrObjectNotExistOrAuthorized
+						}
+						o.Schemas[g.Schema].Objects[g.Object] = o.Schemas[g.Schema].Objects[g.Object].setGrantTo(ModeRead, g)
 					}
-				} // Ignore this grant, it is correct, even if we did not know about the object's existence yet (result of FUTURE grant, probably)
-			case ObjTpTable, ObjTpView:
-				if o.hasObject(g.Schema, g.Object) {
-					if o.Schemas[g.Schema].Objects[g.Object].ObjectType != g.GrantedOn {
-						// A table may have been dropped and a view with the same name created or vice versa
-						// A good reason to refresh the product
-						return o, ErrObjectNotExistOrAuthorized
-					}
-					o.Schemas[g.Schema].Objects[g.Object] = o.Schemas[g.Schema].Objects[g.Object].setGrantTo(ModeRead, g)
-				} else if oms.DisjointFromObject(g.Database, g.Schema, g.Object) {
-					o = o.setRevokeGrantTo(ModeRead, g)
-				} // Ignore this grant, it is correct, even if we did not know about the object's existence yet (result of FUTURE grant, probably)
+					// And we need to keep this grant
+					continue
+				}
+			case PrvOwnership:
+				// WIP TODO
 			}
-			// Ignore this grant, it is not managed by grupr at the moment, sysadmins may have granted it if it is not in grupr's scope currently
+			// If we are still here, we need to revoke this grant
+			o = o.setRevokeGrantTo(ModeRead, g)
 		}
 	}
 	return o, nil

--- a/internal/snowflake/agg_db_objs.go
+++ b/internal/snowflake/agg_db_objs.go
@@ -254,6 +254,7 @@ func (o AggDBObjs) setFutureGrants(ctx context.Context, semCnf *semantics.Config
 					if o.hasSchema(g.Schema) {
 						if o.Schemas[g.Schema].MatchAllObjects {
 							o.Schemas[g.Schema] = o.Schemas[g.Schema].setFutureGrantTo(ModeRead, g)
+							continue
 						}
 						// We need to revoke
 					} else {

--- a/internal/snowflake/agg_db_objs.go
+++ b/internal/snowflake/agg_db_objs.go
@@ -221,14 +221,8 @@ func (o AggDBObjs) setGrants(ctx context.Context, semCnf *semantics.Config, cnf 
 	if !o.isReadDBRoleNew {
 		// First, check for unmanaged grants, and keep track of in which schemas the database role holds unmanaged grants;
 		// We should not revoke USAGE on these schemas from the database role, not even if the schema is disjoint from the YAML.
-
-		// WIP: TODO: there can also be unmanaged grants that are on tables (as they appear in grant records), but
-		// actually they are on types of tables (e.g., external tables, dynamic tables, etc.) that grupr does not manage
-		// access for yet. Therefore, we should only revoke access to schemas once we have processed all revoke
-		// candidates on objects. So, three passes, really. One query for unmanaged grants, one query for what appear to
-		// be managed grants on objects, and one query for grants on schemas.
 		o.schemasWithUnmanagedGrants = map[semantics.Ident]struct{}{}
-		for g, err := range QueryGrantsToDBRoleFiltered(ctx, cnf, conn, db, o.readDBRole.Name, nil, cnf.DatabaseRolePrivileges[ModeRead]) {
+		for g, err := range QueryGrantsToDBRoleFiltered(ctx, cnf, conn, db, o.readDBRole.Name, nil, cnf.ObjectPrivileges) {
 			if err != nil {
 				return o, err
 			}
@@ -239,7 +233,7 @@ func (o AggDBObjs) setGrants(ctx context.Context, semCnf *semantics.Config, cnf 
 		}
 
 		// Second, check for managed grants
-		for g, err := range QueryGrantsToDBRoleFiltered(ctx, cnf, conn, db, o.readDBRole.Name, cnf.DatabaseRolePrivileges[ModeRead], nil) {
+		for g, err := range QueryGrantsToDBRoleFiltered(ctx, cnf, conn, db, o.readDBRole.Name, cnf.ObjectPrivileges, nil) {
 			if err != nil {
 				return o, err
 			}

--- a/internal/snowflake/agg_db_objs.go
+++ b/internal/snowflake/agg_db_objs.go
@@ -221,15 +221,14 @@ func (o AggDBObjs) setFutureGrants(ctx context.Context, semCnf *semantics.Config
 		return o, err
 	}
 	if !o.isReadDBRoleNew {
-		for g, err := range QueryFutureGrantsToDBRoleFiltered(ctx, conn, db, o.readDBRole.Name, cnf.DatabaseRolePrivileges[ModeRead], nil) {
+		for g, err := range QueryFutureGrantsToDBRoleFiltered(ctx, conn, db, o.readDBRole.Name, cnf.ObjectPrivilegesRead, nil) {
 			if err != nil {
 				return o, err
 			}
 
 			if g.Database != db {
-				// This grant should not be granted to this particular database role
-				o = o.setRevokeFutureGrantTo(ModeRead, g)
-				continue
+				// This grant should not be granted to this particular database role, this should not be possible in Snowflake atm (May 2026)
+				return o, fmt.Errorf("privilege granted to database role on future objects from different database")
 			}
 
 			switch g.GrantedIn {
@@ -238,35 +237,37 @@ func (o AggDBObjs) setFutureGrants(ctx context.Context, semCnf *semantics.Config
 				case ObjTpSchema:
 					if o.MatchAllSchemas {
 						o = o.setFutureGrantTo(ModeRead, g)
-					} else {
-						o = o.setRevokeFutureGrantTo(ModeRead, g)
+						continue
 					}
+					// We need to revoke
 				case ObjTpTable, ObjTpView, ObjTpMaterializedView:
 					if o.MatchAllObjects {
 						o = o.setFutureGrantTo(ModeRead, g)
-					} else {
-						o = o.setRevokeFutureGrantTo(ModeRead, g)
+						continue
 					}
+					// We need to revoke
 				}
-				// Ignore this grant, it's not in grupr its scope (unmanaged grant)
 			case ObjTpSchema:
-				if o.hasSchema(g.Schema) {
-					if o.Schemas[g.Schema].MatchAllObjects {
-						o.Schemas[g.Schema] = o.Schemas[g.Schema].setFutureGrantTo(ModeRead, g)
+				switch g.GrantedOn {
+				case ObjTpTable, ObjTpView, ObjTpMaterializedView:
+					if o.hasSchema(g.Schema) {
+						if o.Schemas[g.Schema].MatchAllObjects {
+							o.Schemas[g.Schema] = o.Schemas[g.Schema].setFutureGrantTo(ModeRead, g)
+						}
+						// We need to revoke 
 					} else {
-						o = o.setRevokeFutureGrantTo(ModeRead, g)
-					}
-				} else {
-					// A rare oddity. A schema was added after we loaded account objects,
-					// and future grants were granted in it to our database role, no less.
-					// But, if the YAML indicates this is correct, we will leave the grant intact
-					if !oms.MatchAllObjectsInSchema(db, g.Schema) {
-						o = o.setRevokeFutureGrantTo(ModeRead, g)
+						// A rare oddity. A schema was added after we loaded account objects,
+						// and future grants were granted in it to our database role, no less.
+						// But, if the YAML indicates this is correct, we will leave the grant intact
+						if oms.MatchAllObjectsInSchema(db, g.Schema) {
+							continue
+						}
+						// We need to revoke
 					}
 				}
-			default:
-				panic("unsupported granted_in object type in future grant")
 			}
+			// If we are still here, we need to revoke
+			o = o.setRevokeFutureGrantTo(ModeRead, g)
 		}
 	}
 	return o, nil
@@ -294,7 +295,7 @@ func (o AggDBObjs) setGrants(ctx context.Context, semCnf *semantics.Config, cnf 
 		}
 
 		// Second, check for managed grants
-		for g, err := range QueryGrantsToDBRoleFiltered(ctx, cnf, conn, db, o.readDBRole.Name, cnf.ObjectPrivileges, nil) {
+		for g, err := range QueryGrantsToDBRoleFiltered(ctx, cnf, conn, db, o.readDBRole.Name, cnf.ObjectPrivilegesRead, nil) {
 			if err != nil {
 				return o, err
 			}
@@ -309,7 +310,7 @@ func (o AggDBObjs) setGrants(ctx context.Context, semCnf *semantics.Config, cnf 
 			case ObjTpDatabase:
 				switch g.Privileges[0].Privilege {
 				case PrvMonitor:
-					o.isMonitorGranted = true					
+					o.isMonitorGranted = true
 				case PrvUsage:
 					// PrvUsage comes out of the box, we do not grant it, so no need to mark it as present
 					continue

--- a/internal/snowflake/agg_db_objs.go
+++ b/internal/snowflake/agg_db_objs.go
@@ -254,7 +254,7 @@ func (o AggDBObjs) setFutureGrants(ctx context.Context, semCnf *semantics.Config
 						if o.Schemas[g.Schema].MatchAllObjects {
 							o.Schemas[g.Schema] = o.Schemas[g.Schema].setFutureGrantTo(ModeRead, g)
 						}
-						// We need to revoke 
+						// We need to revoke
 					} else {
 						// A rare oddity. A schema was added after we loaded account objects,
 						// and future grants were granted in it to our database role, no less.
@@ -286,7 +286,7 @@ func (o AggDBObjs) setGrants(ctx context.Context, semCnf *semantics.Config, cnf 
 		//
 		// Note that write privileges on objects are unmanaged from the perspective of a database role. If sysadmins
 		// would grant them to grupr managed database roles, despite best practices, they will have to revoke them also
-		// in case they want grupr to drop the role when it is no longer needed. 
+		// in case they want grupr to drop the role when it is no longer needed.
 		for g, err := range QueryGrantsToDBRoleFilteredLimit(ctx, cnf, conn, db, o.readDBRole.Name, nil, cnf.ObjectPrivilegesRead, 1) {
 			if err != nil {
 				return o, err
@@ -301,7 +301,7 @@ func (o AggDBObjs) setGrants(ctx context.Context, semCnf *semantics.Config, cnf 
 			}
 
 			if g.Database != db {
-				// This grant should not be granted to this particular database role, that should not be 
+				// This grant should not be granted to this particular database role, that should not be
 				// possible in Snowflake, at the moment
 				return o, fmt.Errorf("privilege granted to database role on object from different database")
 			}
@@ -331,7 +331,7 @@ func (o AggDBObjs) setGrants(ctx context.Context, semCnf *semantics.Config, cnf 
 						// Either way, if the schema is matched in the YAML, even if it was not there
 						// when we refreshed objects, the grant is fine, we keep it.
 						continue
-					} 
+					}
 				}
 			case ObjTpTable, ObjTpView, ObjTpMaterializedView:
 				switch g.Privileges[0].Privilege {
@@ -369,7 +369,7 @@ func (o AggDBObjs) setConsumedByGranted(m Mode, pdID semantics.ProductDTAPID) Ag
 	return o
 }
 
-func (o AggDBObjs) pushToDoFutureGrants(cnf *Config, yield func(FutureGrant) bool, map[ObjType]bool mots) bool {
+func (o AggDBObjs) pushToDoFutureGrants(cnf *Config, yield func(FutureGrant) bool, mots map[ObjType]bool) bool {
 	// All future read privileges; write privileges are collected from a ProductDTAP method directly
 	if o.MatchAllSchemas {
 		prvs := []PrivilegeComplete{}

--- a/internal/snowflake/agg_db_objs.go
+++ b/internal/snowflake/agg_db_objs.go
@@ -356,7 +356,7 @@ func (o AggDBObjs) setConsumedByGranted(m Mode, pdID semantics.ProductDTAPID) Ag
 	return o
 }
 
-func (o AggDBObjs) pushToDoFutureGrants(yield func(FutureGrant) bool) bool {
+func (o AggDBObjs) pushToDoFutureGrants(cnf *Config, yield func(FutureGrant) bool, map[ObjType]bool mots) bool {
 	// All future read privileges; write privileges are collected from a ProductDTAP method directly
 	// WIP TODO: monitor in there, and select error table a bit below, much like this method in agg_schema_objs
 	if o.MatchAllSchemas {
@@ -375,11 +375,18 @@ func (o AggDBObjs) pushToDoFutureGrants(yield func(FutureGrant) bool) bool {
 		}
 	}
 	if o.MatchAllObjects {
-		for _, ot := range [2]ObjType{ObjTpTable, ObjTpView, ObjTpMaterializedView} {
+		for ot := range mots {
 			prvs := []PrivilegeComplete{}
-			for _, p := range [2]PrivilegeComplete{PrivilegeComplete{Privilege: PrvSelect}, PrivilegeComplete{Privilege: PrvReferences}} {
-				if !o.hasFutureGrantTo(ModeRead, ot, p) {
-					prvs = append(prvs, p)
+			candidatePrvs := []PrivilegeComplete{
+				PrivilegeComplete{Privilege: PrvSelect},
+				PrivilegeComplete{Privilege: PrvReferences},
+			}
+			if ot == ObjTpTable {
+				candidatePrvs = append(candidatePrvs, PrivilegeComplete{Privilege: PrvSelectErrorTable})
+			}
+			for _, pc := range candidatePrvs {
+				if !o.hasFutureGrantTo(ModeRead, ot, pc) {
+					prvs = append(prvs, pc)
 				}
 			}
 			if len(prvs) > 0 {
@@ -398,7 +405,7 @@ func (o AggDBObjs) pushToDoFutureGrants(yield func(FutureGrant) bool) bool {
 		}
 	}
 	for schema, schemaObjs := range o.Schemas {
-		if !schemaObjs.pushToDoFutureGrants(yield, o.readDBRole, schema) {
+		if !schemaObjs.pushToDoFutureGrants(cnf, yield, o.readDBRole, schema, mots) {
 			return false
 		}
 	}

--- a/internal/snowflake/agg_db_objs.go
+++ b/internal/snowflake/agg_db_objs.go
@@ -16,6 +16,8 @@ type AggDBObjs struct {
 	readDBRole      DatabaseRole
 	isReadDBRoleNew bool // if true, then no need to query grants
 
+	isMonitorGranted bool
+
 	// Does the DB role have unmanaged privileges?
 	hasUnmanagedGrantsReadDBRole bool
 
@@ -275,7 +277,8 @@ func (o AggDBObjs) setGrants(ctx context.Context, semCnf *semantics.Config, cnf 
 		// First, check for unmanaged grants, and keep track of in which schemas the database role holds unmanaged grants;
 		// Since we don't know how to parse grants that grupr does not manage, if there is even a single unmanaged
 		// grant, no matter what it is, we are not going to revoke usage or monitor from any databases or schemas; even
-		// if those databases and schemas do not match any object expression from the YAML. After
+		// if those databases and schemas do not match any object expression from the YAML; even if the objects are
+		// matched by a different product its YAML. After
 		// all, it could be that this would render ineffective an unmanaged privilege on an object in such a schema,
 		// and grupr would break some access that was legitimately put in place by sysadmins.
 		// We should not revoke USAGE on these schemas from the database role, not even if the schema is disjoint from the YAML.
@@ -302,14 +305,18 @@ func (o AggDBObjs) setGrants(ctx context.Context, semCnf *semantics.Config, cnf 
 				return o, fmt.Errorf("privilege granted to database role on object from different database")
 			}
 
-			switch g.Privileges[0].Privilege {
-			case PrvUsage, Monitor:
-				// At the moment, cnf.ObjectPrivileges has these only on databases and schemas
-				switch g.GrantedOn {
-				case ObjTpDatabase:
-					// We need to keep this grant
+			switch ot := g.GrantedOn; ot {
+			case ObjTpDatabase:
+				switch g.Privileges[0].Privilege {
+				case PrvMonitor:
+					o.isMonitorGranted = true					
+				case PrvUsage:
+					// PrvUsage comes out of the box, we do not grant it, so no need to mark it as present
 					continue
-				case ObjTpSchema:
+				}
+			case ObjTpSchema:
+				switch g.Privileges[0].Privilege {
+				case PrvUsage, PrvMonitor:
 					if oms.DisjointFromSchema(g.Database, g.Schema) {
 						if o.hasUnmanagedGrantsReadDBRole {
 							// We need to keep this grant
@@ -325,19 +332,24 @@ func (o AggDBObjs) setGrants(ctx context.Context, semCnf *semantics.Config, cnf 
 						continue
 					} 
 				}
-			case PrvSelect, PrvReferences, PrvSelectErrorTable:
-				// At the moment, we only have this on ObjTpTable and ObjTpView in cnf.ObjectPrivileges
-				if !oms.DisjointFromObject(g.Database, g.Schema, g.Object) { // else, we need to revoke
-					if o.hasObject(g.Schema, g.Object) {
-						if o.Schemas[g.Schema].Objects[g.Object].ObjectType.String() != g.GrantedOn.String() {
-							// A (hybrid) table may have been dropped and a view with the same name created or vice versa
-							// A good reason to refresh the product
-							return o, ErrObjectNotExistOrAuthorized
+			case ObjTpTable, ObjTpView, ObjTpMaterializedView:
+				switch g.Privileges[0].Privilege {
+				case PrvSelect, PrvReferences, PrvSelectErrorTable:
+					if !oms.DisjointFromObject(g.Database, g.Schema, g.Object) {
+						if o.hasObject(g.Schema, g.Object) {
+							// We call the String method on the object type to normalize AggObjAttr.ObjectType from
+							// ObjTpHybridTable to ObjTpTable
+							if o.Schemas[g.Schema].Objects[g.Object].ObjectType.String() != ot.String() {
+								// A (hybrid) table may have been dropped and a (materialized) view with the same name
+								// created or vice versa A good reason to refresh the product
+								return o, ErrObjectNotExistOrAuthorized
+							}
+							o.Schemas[g.Schema].Objects[g.Object] = o.Schemas[g.Schema].Objects[g.Object].setGrantTo(ModeRead, g)
 						}
-						o.Schemas[g.Schema].Objects[g.Object] = o.Schemas[g.Schema].Objects[g.Object].setGrantTo(ModeRead, g)
+						// And we need to keep this grant
+						continue
 					}
-					// And we need to keep this grant
-					continue
+					// We need to revoke
 				}
 			}
 			// If we are still here, we need to revoke this grant
@@ -358,11 +370,19 @@ func (o AggDBObjs) setConsumedByGranted(m Mode, pdID semantics.ProductDTAPID) Ag
 
 func (o AggDBObjs) pushToDoFutureGrants(cnf *Config, yield func(FutureGrant) bool, map[ObjType]bool mots) bool {
 	// All future read privileges; write privileges are collected from a ProductDTAP method directly
-	// WIP TODO: monitor in there, and select error table a bit below, much like this method in agg_schema_objs
 	if o.MatchAllSchemas {
-		if !o.hasFutureGrantTo(ModeRead, ObjTpSchema, PrivilegeComplete{Privilege: PrvUsage}) {
+		prvs := []PrivilegeComplete{}
+		for _, pc := range [2]PrivilegeComplete{
+			PrivilegeComplete{Privilege: PrvUsage},
+			PrivilegeComplete{Privilege: PrvMonitor},
+		} {
+			if !o.hasFutureGrantTo(ModeRead, ObjTpSchema, pc) {
+				prvs = append(prvs, pc)
+			}
+		}
+		if len(prvs) > 0 {
 			if !yield(FutureGrant{
-				Privileges:        []PrivilegeComplete{PrivilegeComplete{Privilege: PrvUsage}},
+				Privileges:        prvs,
 				GrantedOn:         ObjTpSchema,
 				GrantedIn:         ObjTpDatabase,
 				Database:          o.readDBRole.Database,
@@ -382,6 +402,8 @@ func (o AggDBObjs) pushToDoFutureGrants(cnf *Config, yield func(FutureGrant) boo
 				PrivilegeComplete{Privilege: PrvReferences},
 			}
 			if ot == ObjTpTable {
+				// Note that this privilege does not apply to hybrid tables, but we count on
+				// Snowflake not giving problems when folks create a hybrid table
 				candidatePrvs = append(candidatePrvs, PrivilegeComplete{Privilege: PrvSelectErrorTable})
 			}
 			for _, pc := range candidatePrvs {
@@ -413,6 +435,18 @@ func (o AggDBObjs) pushToDoFutureGrants(cnf *Config, yield func(FutureGrant) boo
 }
 
 func (o AggDBObjs) pushToDoGrants(yield func(Grant) bool) bool {
+	if !o.isMonitorGranted {
+		if !yield(Grant{
+			Privileges:        []PrivilegeComplete{PrivilegeComplete{Privilege: PrvMonitor}},
+			GrantedOn:         ObjTpDatabase,
+			Database:          o.readDBRole.Database,
+			GrantedTo:         ObjTpDatabaseRole,
+			GrantedToDatabase: o.readDBRole.Database,
+			GrantedToName:     o.readDBRole.Name,
+		}) {
+			return false
+		}
+	}
 	for schema, schemaObjs := range o.Schemas {
 		if !schemaObjs.pushToDoGrants(yield, o.readDBRole, schema) {
 			return false

--- a/internal/snowflake/agg_db_objs.go
+++ b/internal/snowflake/agg_db_objs.go
@@ -20,13 +20,16 @@ type AggDBObjs struct {
 	hasUnmanagedGrantsReadDBRole bool
 
 	// Grants to the readDBRole
-	isUsageGrantedOnFutureSchemasToReadDBRole bool
+	isPrivilegeGrantedOnFutureSchemasToReadDBRole [2]bool
 	// Small lookup table, first index rows, second index columns
-	//   		0: PrvSelect	1: PrvRefernces
-	// 0: ObjTable
-	// 1: ObjView
+	//   		0: PrvSelect	1: PrvSelectErrorTable	2: PrvRefernces
+	// 0: ObjTpTable
+	// 1: ObjTpView
+	// 2: ObjTpMaterializedView
 	//
-	isPrivilegeOnFutureObjectGrantedToReadDBRole [2][2]bool
+	// Note: PrvSelectErrorTable is only applicable to ObjTpTable,
+	// so this representation does waste a little space.
+	isPrivilegeOnFutureObjectGrantedToReadDBRole [7]bool
 	revokeGrantsToReadDBRole                     []Grant
 	revokeFutureGrantsToReadDBRole               []FutureGrant
 
@@ -38,7 +41,7 @@ type AggDBObjs struct {
 	isReadDBRoleGrantedToProductRole [2]bool // directly set from within Grupin.setDBRoleGrants
 
 	// Grants to the product write role; only used if this AggDBObjs is part of a product level interface
-	isCreateObjectOnFutureSchemasGrantedToProductWriteRole [2]bool // 0: ObjTable, 1: ObjView
+	isCreateObjectOnFutureSchemasGrantedToProductWriteRole [3]bool // 0: ObjTpTable, 1: ObjTpView, 2: ObjTpMaterializedView
 
 }
 
@@ -73,31 +76,54 @@ func (o AggDBObjs) setFutureGrantTo(m Mode, g FutureGrant) AggDBObjs {
 		case ObjTpSchema:
 			switch g.Privileges[0].Privilege {
 			case PrvUsage:
-				o.isUsageGrantedOnFutureSchemasToReadDBRole = true
+				o.isPrivilegeGrantedOnFutureSchemasToReadDBRole[0] = true
+			case PrvMonitor:
+				o.isPrivilegeGrantedOnFutureSchemasToReadDBRole[1] = true
 			}
-			// Ignore; unmanaged grant
-		case ObjTpTable, ObjTpView:
+		case ObjTpTable:
 			switch g.Privileges[0].Privilege {
-			case PrvSelect, PrvReferences:
-				o.isPrivilegeOnFutureObjectGrantedToReadDBRole[g.GrantedOn.getIdxObjectLevel()][g.Privileges[0].Privilege.getIdxObjectLevel()] = true
+			case PrvSelect:
+				o.isPrivilegeOnFutureObjectGrantedToReadDBRole[0] = true
+			case PrvSelectErrorTable:
+				o.isPrivilegeOnFutureObjectGrantedToReadDBRole[1] = true
+			case PrvReferences:
+				o.isPrivilegeOnFutureObjectGrantedToReadDBRole[2] = true
 			}
-			// Ignore; unmanaged grant
+		case ObjTpView:
+			switch g.Privileges[0].Privilege {
+			case PrvSelect:
+				o.isPrivilegeOnFutureObjectGrantedToReadDBRole[3] = true
+			case PrvReferences:
+				o.isPrivilegeOnFutureObjectGrantedToReadDBRole[4] = true
+			}
+		case ObjTpMaterializedView:
+			switch g.Privileges[0].Privilege {
+			case PrvSelect:
+				o.isPrivilegeOnFutureObjectGrantedToReadDBRole[5] = true
+			case PrvReferences:
+				o.isPrivilegeOnFutureObjectGrantedToReadDBRole[6] = true
+			}
 		}
 	case ModeWrite:
 		switch g.GrantedOn {
 		case ObjTpSchema:
-			switch g.Privileges[0].Privilege {
+			switch pc := g.Privileges[0]; pc.Privilege {
 			case PrvCreate:
-				o.isCreateObjectOnFutureSchemasGrantedToProductWriteRole[g.Privileges[0].CreateObjectType.getIdxObjectLevel()] = true
+				switch pc.CreateObjectType {
+				case ObjTpTable:
+					o.isCreateObjectOnFutureSchemasGrantedToProductWriteRole[0] = true
+				case ObjTpView:
+					o.isCreateObjectOnFutureSchemasGrantedToProductWriteRole[1] = true
+				case ObjTpMaterializedView:
+					o.isCreateObjectOnFutureSchemasGrantedToProductWriteRole[2] = true
+				}
 			}
-			// Ignore, unmanaged grant
 		}
-		// Ignore, unmanaged grant
 	}
 	return o
 }
 
-func (o AggDBObjs) hasFutureGrantTo(m Mode, grantedOn ObjType, p PrivilegeComplete) bool {
+func (o AggDBObjs) hasFutureGrantTo(m Mode, grantedOn ObjType, pc PrivilegeComplete) bool {
 	// Used for setting if grants on future objects in AggDBObjs have been
 	// granted to either the readDBRole (ModeRead) or the ProductWriteRole
 	// (ModeWrite)
@@ -105,22 +131,49 @@ func (o AggDBObjs) hasFutureGrantTo(m Mode, grantedOn ObjType, p PrivilegeComple
 	case ModeRead:
 		switch grantedOn {
 		case ObjTpSchema:
-			switch p.Privilege {
+			switch pc.Privilege {
 			case PrvUsage:
-				return o.isUsageGrantedOnFutureSchemasToReadDBRole
+				return o.isPrivilegeGrantedOnFutureSchemasToReadDBRole[0]
+			case PrvMonitor:
+				return o.isPrivilegeGrantedOnFutureSchemasToReadDBRole[1]
 			}
-		case ObjTpTable, ObjTpView:
-			switch p.Privilege {
-			case PrvSelect, PrvReferences:
-				return o.isPrivilegeOnFutureObjectGrantedToReadDBRole[grantedOn.getIdxObjectLevel()][p.Privilege.getIdxObjectLevel()]
+		case ObjTpTable:
+			switch pc.Privilege {
+			case PrvSelect:
+				return o.isPrivilegeOnFutureObjectGrantedToReadDBRole[0]
+			case PrvSelectErrorTable:
+				return o.isPrivilegeOnFutureObjectGrantedToReadDBRole[1]
+			case PrvReferences:
+				return o.isPrivilegeOnFutureObjectGrantedToReadDBRole[2]
+			}
+		case ObjTpView:
+			switch pc.Privilege {
+			case PrvSelect:
+				return o.isPrivilegeOnFutureObjectGrantedToReadDBRole[3]
+			case PrvReferences:
+				return o.isPrivilegeOnFutureObjectGrantedToReadDBRole[4]
+			}
+		case ObjTpMaterializedView:
+			switch pc.Privilege {
+			case PrvSelect:
+				return o.isPrivilegeOnFutureObjectGrantedToReadDBRole[5]
+			case PrvReferences:
+				return o.isPrivilegeOnFutureObjectGrantedToReadDBRole[6]
 			}
 		}
 	case ModeWrite:
 		switch grantedOn {
 		case ObjTpSchema:
-			switch p.Privilege {
+			switch pc.Privilege {
 			case PrvCreate:
-				return o.isCreateObjectOnFutureSchemasGrantedToProductWriteRole[grantedOn.getIdxObjectLevel()]
+				switch pc.CreateObjectType {
+				case ObjTpTable:
+					return o.isCreateObjectOnFutureSchemasGrantedToProductWriteRole[0]
+				case ObjTpView:
+					return o.isCreateObjectOnFutureSchemasGrantedToProductWriteRole[1]
+				case ObjTpMaterializedView:
+					return o.isCreateObjectOnFutureSchemasGrantedToProductWriteRole[2]
+				}
 			}
 		}
 	}
@@ -186,7 +239,7 @@ func (o AggDBObjs) setFutureGrants(ctx context.Context, semCnf *semantics.Config
 					} else {
 						o = o.setRevokeFutureGrantTo(ModeRead, g)
 					}
-				case ObjTpTable, ObjTpView:
+				case ObjTpTable, ObjTpView, ObjTpMaterializedView:
 					if o.MatchAllObjects {
 						o = o.setFutureGrantTo(ModeRead, g)
 					} else {
@@ -304,6 +357,8 @@ func (o AggDBObjs) setConsumedByGranted(m Mode, pdID semantics.ProductDTAPID) Ag
 }
 
 func (o AggDBObjs) pushToDoFutureGrants(yield func(FutureGrant) bool) bool {
+	// All future read privileges; write privileges are collected from a ProductDTAP method directly
+	// WIP TODO: monitor in there, and select error table a bit below, much like this method in agg_schema_objs
 	if o.MatchAllSchemas {
 		if !o.hasFutureGrantTo(ModeRead, ObjTpSchema, PrivilegeComplete{Privilege: PrvUsage}) {
 			if !yield(FutureGrant{
@@ -320,7 +375,7 @@ func (o AggDBObjs) pushToDoFutureGrants(yield func(FutureGrant) bool) bool {
 		}
 	}
 	if o.MatchAllObjects {
-		for _, ot := range [2]ObjType{ObjTpTable, ObjTpView} {
+		for _, ot := range [2]ObjType{ObjTpTable, ObjTpView, ObjTpMaterializedView} {
 			prvs := []PrivilegeComplete{}
 			for _, p := range [2]PrivilegeComplete{PrivilegeComplete{Privilege: PrvSelect}, PrivilegeComplete{Privilege: PrvReferences}} {
 				if !o.hasFutureGrantTo(ModeRead, ot, p) {

--- a/internal/snowflake/agg_db_objs.go
+++ b/internal/snowflake/agg_db_objs.go
@@ -221,6 +221,12 @@ func (o AggDBObjs) setGrants(ctx context.Context, semCnf *semantics.Config, cnf 
 	if !o.isReadDBRoleNew {
 		// First, check for unmanaged grants, and keep track of in which schemas the database role holds unmanaged grants;
 		// We should not revoke USAGE on these schemas from the database role, not even if the schema is disjoint from the YAML.
+
+		// WIP: TODO: there can also be unmanaged grants that are on tables (as they appear in grant records), but
+		// actually they are on types of tables (e.g., external tables, dynamic tables, etc.) that grupr does not manage
+		// access for yet. Therefore, we should only revoke access to schemas once we have processed all revoke
+		// candidates on objects. So, three passes, really. One query for unmanaged grants, one query for what appear to
+		// be managed grants on objects, and one query for grants on schemas.
 		o.schemasWithUnmanagedGrants = map[semantics.Ident]struct{}{}
 		for g, err := range QueryGrantsToDBRoleFiltered(ctx, cnf, conn, db, o.readDBRole.Name, nil, cnf.DatabaseRolePrivileges[ModeRead]) {
 			if err != nil {

--- a/internal/snowflake/agg_db_objs.go
+++ b/internal/snowflake/agg_db_objs.go
@@ -3,6 +3,7 @@ package snowflake
 import (
 	"context"
 	"database/sql"
+	"fmt"
 
 	"github.com/rwberendsen/grupr/internal/semantics"
 )
@@ -287,7 +288,7 @@ func (o AggDBObjs) setGrants(ctx context.Context, semCnf *semantics.Config, cnf 
 		// Note that write privileges on objects are unmanaged from the perspective of a database role. If sysadmins
 		// would grant them to grupr managed database roles, despite best practices, they will have to revoke them also
 		// in case they want grupr to drop the role when it is no longer needed.
-		for g, err := range QueryGrantsToDBRoleFilteredLimit(ctx, cnf, conn, db, o.readDBRole.Name, nil, cnf.ObjectPrivilegesRead, 1) {
+		for _, err := range QueryGrantsToDBRoleFilteredLimit(ctx, cnf, conn, db, o.readDBRole.Name, nil, cnf.ObjectPrivilegesRead, 1) {
 			if err != nil {
 				return o, err
 			}
@@ -369,7 +370,7 @@ func (o AggDBObjs) setConsumedByGranted(m Mode, pdID semantics.ProductDTAPID) Ag
 	return o
 }
 
-func (o AggDBObjs) pushToDoFutureGrants(cnf *Config, yield func(FutureGrant) bool, mots map[ObjType]bool) bool {
+func (o AggDBObjs) pushToDoFutureGrants(yield func(FutureGrant) bool, mots map[ObjType]bool) bool {
 	// All future read privileges; write privileges are collected from a ProductDTAP method directly
 	if o.MatchAllSchemas {
 		prvs := []PrivilegeComplete{}
@@ -428,7 +429,7 @@ func (o AggDBObjs) pushToDoFutureGrants(cnf *Config, yield func(FutureGrant) boo
 		}
 	}
 	for schema, schemaObjs := range o.Schemas {
-		if !schemaObjs.pushToDoFutureGrants(cnf, yield, o.readDBRole, schema, mots) {
+		if !schemaObjs.pushToDoFutureGrants(yield, o.readDBRole, schema, mots) {
 			return false
 		}
 	}

--- a/internal/snowflake/agg_obj_attr.go
+++ b/internal/snowflake/agg_obj_attr.go
@@ -51,6 +51,8 @@ func (o AggObjAttr) hasGrantTo(m Mode, p Privilege) bool {
 
 func (o AggObjAttr) pushToDoGrants(yield func(Grant) bool, dbRole DatabaseRole, schema semantics.Ident, obj semantics.Ident) bool {
 	prvs := []PrivilegeComplete{}
+	// WIP TODO PrvReferences is not there for dynamic tables and online feature tables, are we 100% sure the latter is
+	// not in the output of show objects? If so, granting REFERENCES may fail
 	for _, p := range [2]Privilege{PrvSelect, PrvReferences} {
 		if !o.hasGrantTo(ModeRead, p) {
 			prvs = append(prvs, PrivilegeComplete{Privilege: p})

--- a/internal/snowflake/agg_obj_attr.go
+++ b/internal/snowflake/agg_obj_attr.go
@@ -63,6 +63,7 @@ func (o AggObjAttr) pushToDoGrants(yield func(Grant) bool, dbRole DatabaseRole, 
 		PrivilegeComplete{Privilege: PrvReferences},
 	}
 	if o.ObjectType == ObjTpTable {
+		// We do not want this privilege for views, materialized views and hybrid tables
 		candidatePrvs = append(candidatePrvs, PrivilegeComplete{Privilege: PrvSelectErrorTable})
 	}
 	for _, pc := range candidatePrvs {
@@ -73,7 +74,7 @@ func (o AggObjAttr) pushToDoGrants(yield func(Grant) bool, dbRole DatabaseRole, 
 	if len(prvs) > 0 {
 		if !yield(Grant{
 			Privileges:        prvs,
-			GrantedOn:         o.ObjectType,
+			GrantedOn:         ParseObjType(o.ObjectType.String()), // will normalize ObjHybridTable to ObjTable
 			Database:          dbRole.Database,
 			Schema:            schema,
 			Object:            obj,

--- a/internal/snowflake/agg_obj_attr.go
+++ b/internal/snowflake/agg_obj_attr.go
@@ -9,9 +9,10 @@ type AggObjAttr struct {
 	Owner      semantics.Ident
 
 	// set when grant() is called on AggDBObjs
-	isSelectGrantedToReadDBRole     bool
-	isReferencesGrantedToReadDBRole bool
-	isOwnedByProductWriteRole       bool
+	isSelectGrantedToReadDBRole           bool
+	isSelectErrorTableGrantedToReadDBRole bool
+	isReferencesGrantedToReadDBRole       bool
+	isOwnedByProductWriteRole             bool
 }
 
 func (o AggObjAttr) setGrantTo(m Mode, g Grant) AggObjAttr {
@@ -20,6 +21,10 @@ func (o AggObjAttr) setGrantTo(m Mode, g Grant) AggObjAttr {
 		switch g.Privileges[0].Privilege {
 		case PrvSelect:
 			o.isSelectGrantedToReadDBRole = true
+		case PrvSelectErrorTable:
+			// Note, this is of course only valid for a regular table,
+			// but, we won't expect it to be called with an invalid grant like doing this on a view, for example.
+			o.isSelectErrorTableGrantedToReadDBRole = true
 		case PrvReferences:
 			o.isReferencesGrantedToReadDBRole = true
 		}
@@ -42,6 +47,8 @@ func (o AggObjAttr) hasGrantTo(m Mode, p Privilege) bool {
 		switch p {
 		case PrvSelect:
 			return o.isSelectGrantedToReadDBRole
+		case PrvSelectErrorTable:
+			return o.isSelectErrorTableGrantedToReadDBRole
 		case PrvReferences:
 			return o.isReferencesGrantedToReadDBRole
 		}
@@ -51,11 +58,16 @@ func (o AggObjAttr) hasGrantTo(m Mode, p Privilege) bool {
 
 func (o AggObjAttr) pushToDoGrants(yield func(Grant) bool, dbRole DatabaseRole, schema semantics.Ident, obj semantics.Ident) bool {
 	prvs := []PrivilegeComplete{}
-	// WIP TODO PrvReferences is not there for dynamic tables and online feature tables, are we 100% sure the latter is
-	// not in the output of show objects? If so, granting REFERENCES may fail
-	for _, p := range [2]Privilege{PrvSelect, PrvReferences} {
-		if !o.hasGrantTo(ModeRead, p) {
-			prvs = append(prvs, PrivilegeComplete{Privilege: p})
+	candidatePrvs := []PrivilegeComplete{
+		PrivilegeComplete{Privilege: PrvSelect},
+		PrivilegeComplete{Privilege: PrvReferences},
+	}
+	if o.ObjectType == ObjTpTable {
+		candidatePrvs = append(candidatePrvs, PrivilegeComplete{Privilege: PrvSelectErrorTable})
+	}
+	for _, pc := range candidatePrvs {
+		if !o.hasGrantTo(ModeRead, pc.Privilege) {
+			prvs = append(prvs, pc)
 		}
 	}
 	if len(prvs) > 0 {

--- a/internal/snowflake/agg_schema_objs.go
+++ b/internal/snowflake/agg_schema_objs.go
@@ -147,11 +147,11 @@ func (o AggSchemaObjs) hasGrantTo(m Mode, pc PrivilegeComplete) bool {
 	return false
 }
 
-func (o AggSchemaObjs) pushToDoFutureGrants(yield func(FutureGrant) bool, dbRole DatabaseRole, schema semantics.Ident) bool {
+func (o AggSchemaObjs) pushToDoFutureGrants(yield func(FutureGrant) bool, dbRole DatabaseRole, schema semantics.Ident, map[ObjType]bool mots) bool {
 	if o.MatchAllObjects {
-		for _, ot := range [2]ObjType{ObjTpTable, ObjTpView, ObjTpMaterializedView} {
+		for ot := range mots {
 			prvs := []PrivilegeComplete{}
-			candidatePrvs:= []PrivilegeComplete{
+			candidatePrvs := []PrivilegeComplete{
 				PrivilegeComplete{Privilege: PrvSelect},
 				PrivilegeComplete{Privilege: PrvReferences},
 			}

--- a/internal/snowflake/agg_schema_objs.go
+++ b/internal/snowflake/agg_schema_objs.go
@@ -9,9 +9,10 @@ type AggSchemaObjs struct {
 	MatchAllObjects bool
 
 	// set while grants are being set
-	isUsageGrantedToReadDBRole                   bool
-	isPrivilegeOnFutureObjectGrantedToReadDBRole [2][2]bool // [ObjType][Privilege]
-	isCreateGrantedToProductWriteRole            [2]bool    // [ObjType]
+	// We need also monitor
+	isPrivilegeOnFutureObjectGrantedToReadDBRole [7]bool
+	isPrivilegeGrantedToReadDBRole               [2]bool
+	isCreateGrantedToProductWriteRole            [3]bool
 }
 
 func newAggSchemaObjs(o SchemaObjs) AggSchemaObjs {
@@ -33,52 +34,114 @@ func (o AggSchemaObjs) hasObject(k semantics.Ident) bool {
 func (o AggSchemaObjs) setFutureGrantTo(_ Mode, g FutureGrant) AggSchemaObjs {
 	// Currently, only ModeRead privileges on future objects in schemas are managed
 	switch g.GrantedOn {
-	case ObjTpTable, ObjTpView:
+	case ObjTpTable:
 		switch g.Privileges[0].Privilege {
-		case PrvSelect, PrvReferences:
-			o.isPrivilegeOnFutureObjectGrantedToReadDBRole[g.GrantedOn.getIdxObjectLevel()][g.Privileges[0].Privilege.getIdxObjectLevel()] = true
+		case PrvSelect:
+			o.isPrivilegeOnFutureObjectGrantedToReadDBRole[0] = true
+		case PrvSelectErrorTable:
+			o.isPrivilegeOnFutureObjectGrantedToReadDBRole[1] = true
+		case PrvReferences:
+			o.isPrivilegeOnFutureObjectGrantedToReadDBRole[2] = true
 		}
-		// Ignore; unmanaged grant
+	case ObjTpView:
+		switch g.Privileges[0].Privilege {
+		case PrvSelect:
+			o.isPrivilegeOnFutureObjectGrantedToReadDBRole[3] = true
+		case PrvReferences:
+			o.isPrivilegeOnFutureObjectGrantedToReadDBRole[4] = true
+		}
+	case ObjTpMaterializedView:
+		switch g.Privileges[0].Privilege {
+		case PrvSelect:
+			o.isPrivilegeOnFutureObjectGrantedToReadDBRole[5] = true
+		case PrvReferences:
+			o.isPrivilegeOnFutureObjectGrantedToReadDBRole[6] = true
+		}
 	}
-	// Ignore; unmanaged grant
 	return o
 }
 
 func (o AggSchemaObjs) hasFutureGrantTo(_ Mode, grantedOn ObjType, p Privilege) bool {
 	// Currently, only ModeRead privileges on future objects in schemas are managed
-	switch grantedOn {
-	case ObjTpTable, ObjTpView:
-		switch p {
-		case PrvSelect, PrvReferences:
-			return o.isPrivilegeOnFutureObjectGrantedToReadDBRole[grantedOn.getIdxObjectLevel()][p.getIdxObjectLevel()]
+	switch g.GrantedOn {
+	case ObjTpTable:
+		switch g.Privileges[0].Privilege {
+		case PrvSelect:
+			return o.isPrivilegeOnFutureObjectGrantedToReadDBRole[0]
+		case PrvSelectErrorTable:
+			return o.isPrivilegeOnFutureObjectGrantedToReadDBRole[1]
+		case PrvReferences:
+			return o.isPrivilegeOnFutureObjectGrantedToReadDBRole[2]
+		}
+	case ObjTpView:
+		switch g.Privileges[0].Privilege {
+		case PrvSelect:
+			return o.isPrivilegeOnFutureObjectGrantedToReadDBRole[3]
+		case PrvReferences:
+			return o.isPrivilegeOnFutureObjectGrantedToReadDBRole[4]
+		}
+	case ObjTpMaterializedView:
+		switch g.Privileges[0].Privilege {
+		case PrvSelect:
+			return o.isPrivilegeOnFutureObjectGrantedToReadDBRole[5]
+		case PrvReferences:
+			return o.isPrivilegeOnFutureObjectGrantedToReadDBRole[6]
 		}
 	}
-	return false
+	return false 
 }
 
 func (o AggSchemaObjs) setGrantTo(m Mode, g Grant) AggSchemaObjs {
-	if m == ModeRead && g.Privileges[0].Privilege == PrvUsage {
-		o.isUsageGrantedToReadDBRole = true
+	switch m {
+	case ModeRead:
+		switch g.GrantedOn {
+		case ObjTpSchema:
+			switch g.Privileges[0].Privilege {
+			case PrvUsage:
+				o.isPrivilegeGrantedToReadDBRole[0] = true
+			case PrvMonitor:
+				o.isPrivilegeGrantedToReadDBRole[1] = true
+			}
+		}
+	case ModeWrite:
+		switch g.GrantedOn {
+		case ObjTpSchema:
+			switch pc := g.Privileges[0]; pc.Privilege {
+			case PrvCreate:
+				switch pc.CreateObjType {
+				case ObjTpTable:
+					o.isCreateGrantedToProductWriteRole[0] = true
+				case ObjTpView:
+					o.isCreateGrantedToProductWriteRole[1] = true
+				case ObjTpMaterializedView:
+					o.isCreateGrantedToProductWriteRole[2] = true
+				}
+			}
+		}
 	}
-	if m == ModeWrite && g.Privileges[0].Privilege == PrvCreate &&
-		(g.Privileges[0].CreateObjectType == ObjTpTable || g.Privileges[0].CreateObjectType == ObjTpView) {
-		o.isCreateGrantedToProductWriteRole[g.Privileges[0].CreateObjectType.getIdxObjectLevel()] = true
-	}
-	// Ignore; unmanaged grant
 	return o
 }
 
-func (o AggSchemaObjs) hasGrantTo(m Mode, p PrivilegeComplete) bool {
+func (o AggSchemaObjs) hasGrantTo(m Mode, pc PrivilegeComplete) bool {
 	switch m {
 	case ModeRead:
-		switch p.Privilege {
+		switch pc.Privilege {
 		case PrvUsage:
-			return o.isUsageGrantedToReadDBRole
+			return o.isPrivilegeGrantedToReadDBRole[0]
+		case PrvMonitor:
+			return o.isPrivilegeGrantedToReadDBRole[1]
 		}
 	case ModeWrite:
-		switch p.Privilege {
+		switch pc.Privilege {
 		case PrvCreate:
-			return o.isCreateGrantedToProductWriteRole[p.CreateObjectType.getIdxObjectLevel()]
+			switch pc.CreateObjType {
+			case ObjTpTable:
+				return o.isCreateGrantedToProductWriteRole[0]
+			case ObjTpView:
+				return o.isCreateGrantedToProductWriteRole[1]
+			case ObjTpMaterializedView:
+				return o.isCreateGrantedToProductWriteRole[2]
+			}
 		}
 	}
 	return false
@@ -86,11 +149,22 @@ func (o AggSchemaObjs) hasGrantTo(m Mode, p PrivilegeComplete) bool {
 
 func (o AggSchemaObjs) pushToDoFutureGrants(yield func(FutureGrant) bool, dbRole DatabaseRole, schema semantics.Ident) bool {
 	if o.MatchAllObjects {
-		for _, ot := range [2]ObjType{ObjTpTable, ObjTpView} {
+		for _, ot := range [2]ObjType{ObjTpTable, ObjTpView, ObjTpMaterializedView} {
 			prvs := []PrivilegeComplete{}
-			for _, p := range [2]Privilege{PrvSelect, PrvReferences} {
-				if !o.hasFutureGrantTo(ModeRead, ot, p) {
-					prvs = append(prvs, PrivilegeComplete{Privilege: p})
+			candidatePrvs:= []PrivilegeComplete{
+				PrivilegeComplete{Privilege: PrvSelect},
+				PrivilegeComplete{Privilege: PrvReferences},
+			}
+			if ot == ObjTpTable {
+				candidatePrvs = append(candidatePrvs, PrivilegeComplete{Privilege: PrvSelectErrorTable})
+			}
+			// Note: counting on this: if you grant select error table on future tables, and you later create a
+			// hybrid table, then Snowflake should not generate an error somehow that select error table is not
+			// valid on a hybrid table
+			for _, pc := range candidatePrvs {
+				if !o.hasFutureGrantTo(ModeRead, ot, pc.Privilege) {
+						prvs = append(prvs, pc)
+					}
 				}
 			}
 			if len(prvs) > 0 {
@@ -113,9 +187,18 @@ func (o AggSchemaObjs) pushToDoFutureGrants(yield func(FutureGrant) bool, dbRole
 }
 
 func (o AggSchemaObjs) pushToDoGrants(yield func(Grant) bool, dbRole DatabaseRole, schema semantics.Ident) bool {
-	if !o.hasGrantTo(ModeRead, PrivilegeComplete{Privilege: PrvUsage}) {
+	prvs := []PrivilegeComplete{}
+	for _, pc := range [2]PrivilegeComplete{
+		PrivilegeComplete{Privilege: PrvUsage},
+		PrivilegeComplete{Privilege: PrvMonitor},
+	} {
+		if !o.hasGrantTo(ModeRead, pc) {
+			prvs = append(prvs, pc)
+		}
+	}
+	if len(prvs) > 0 {
 		if !yield(Grant{
-			Privileges:        []PrivilegeComplete{PrivilegeComplete{Privilege: PrvUsage}},
+			Privileges:        prvs,
 			GrantedOn:         ObjTpSchema,
 			Database:          dbRole.Database,
 			Schema:            schema,

--- a/internal/snowflake/agg_schema_objs.go
+++ b/internal/snowflake/agg_schema_objs.go
@@ -63,9 +63,9 @@ func (o AggSchemaObjs) setFutureGrantTo(_ Mode, g FutureGrant) AggSchemaObjs {
 
 func (o AggSchemaObjs) hasFutureGrantTo(_ Mode, grantedOn ObjType, p Privilege) bool {
 	// Currently, only ModeRead privileges on future objects in schemas are managed
-	switch g.GrantedOn {
+	switch grantedOn {
 	case ObjTpTable:
-		switch g.Privileges[0].Privilege {
+		switch p {
 		case PrvSelect:
 			return o.isPrivilegeOnFutureObjectGrantedToReadDBRole[0]
 		case PrvSelectErrorTable:
@@ -74,14 +74,14 @@ func (o AggSchemaObjs) hasFutureGrantTo(_ Mode, grantedOn ObjType, p Privilege) 
 			return o.isPrivilegeOnFutureObjectGrantedToReadDBRole[2]
 		}
 	case ObjTpView:
-		switch g.Privileges[0].Privilege {
+		switch p {
 		case PrvSelect:
 			return o.isPrivilegeOnFutureObjectGrantedToReadDBRole[3]
 		case PrvReferences:
 			return o.isPrivilegeOnFutureObjectGrantedToReadDBRole[4]
 		}
 	case ObjTpMaterializedView:
-		switch g.Privileges[0].Privilege {
+		switch p {
 		case PrvSelect:
 			return o.isPrivilegeOnFutureObjectGrantedToReadDBRole[5]
 		case PrvReferences:
@@ -108,7 +108,7 @@ func (o AggSchemaObjs) setGrantTo(m Mode, g Grant) AggSchemaObjs {
 		case ObjTpSchema:
 			switch pc := g.Privileges[0]; pc.Privilege {
 			case PrvCreate:
-				switch pc.CreateObjType {
+				switch pc.CreateObjectType {
 				case ObjTpTable:
 					o.isCreateGrantedToProductWriteRole[0] = true
 				case ObjTpView:
@@ -134,7 +134,7 @@ func (o AggSchemaObjs) hasGrantTo(m Mode, pc PrivilegeComplete) bool {
 	case ModeWrite:
 		switch pc.Privilege {
 		case PrvCreate:
-			switch pc.CreateObjType {
+			switch pc.CreateObjectType {
 			case ObjTpTable:
 				return o.isCreateGrantedToProductWriteRole[0]
 			case ObjTpView:

--- a/internal/snowflake/agg_schema_objs.go
+++ b/internal/snowflake/agg_schema_objs.go
@@ -88,7 +88,7 @@ func (o AggSchemaObjs) hasFutureGrantTo(_ Mode, grantedOn ObjType, p Privilege) 
 			return o.isPrivilegeOnFutureObjectGrantedToReadDBRole[6]
 		}
 	}
-	return false 
+	return false
 }
 
 func (o AggSchemaObjs) setGrantTo(m Mode, g Grant) AggSchemaObjs {
@@ -147,7 +147,8 @@ func (o AggSchemaObjs) hasGrantTo(m Mode, pc PrivilegeComplete) bool {
 	return false
 }
 
-func (o AggSchemaObjs) pushToDoFutureGrants(yield func(FutureGrant) bool, dbRole DatabaseRole, schema semantics.Ident, map[ObjType]bool mots) bool {
+func (o AggSchemaObjs) pushToDoFutureGrants(yield func(FutureGrant) bool, dbRole DatabaseRole, schema semantics.Ident,
+	mots map[ObjType]bool) bool {
 	if o.MatchAllObjects {
 		for ot := range mots {
 			prvs := []PrivilegeComplete{}
@@ -163,8 +164,7 @@ func (o AggSchemaObjs) pushToDoFutureGrants(yield func(FutureGrant) bool, dbRole
 			// valid on a hybrid table
 			for _, pc := range candidatePrvs {
 				if !o.hasFutureGrantTo(ModeRead, ot, pc.Privilege) {
-						prvs = append(prvs, pc)
-					}
+					prvs = append(prvs, pc)
 				}
 			}
 			if len(prvs) > 0 {

--- a/internal/snowflake/config.go
+++ b/internal/snowflake/config.go
@@ -159,11 +159,23 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 			GrantedOn:         ObjTpDatabase,
 		}: {},
 		GrantTemplate{
+			PrivilegeComplete: PrivilegeComplete{Privilege: PrvMonitor},
+			GrantedOn:         ObjTpDatabase,
+		}: {},
+		GrantTemplate{
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvUsage},
 			GrantedOn:         ObjTpSchema,
 		}: {},
 		GrantTemplate{
+			PrivilegeComplete: PrivilegeComplete{Privilege: PrvMonitor},
+			GrantedOn:         ObjTpSchema,
+		}: {},
+		GrantTemplate{
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvSelect},
+			GrantedOn:         ObjTpTable,
+		}: {},
+		GrantTemplate{
+			PrivilegeComplete: PrivilegeComplete{Privilege: PrvSelectErrorTable},
 			GrantedOn:         ObjTpTable,
 		}: {},
 		GrantTemplate{
@@ -225,6 +237,30 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 		GrantTemplate{
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvOperate},
 			GrantedOn:         ObjTpWarehouse,
+		}: {},
+		GrantTemplate{
+			PrivilegeComplete: PrivilegeComplete{Privilege: PrvInsert},
+			GrantedOn:         ObjTpTable,
+		}: {},
+		GrantTemplate{
+			PrivilegeComplete: PrivilegeComplete{Privilege: PrvUpdate},
+			GrantedOn:         ObjTpTable,
+		}: {},
+		GrantTemplate{
+			PrivilegeComplete: PrivilegeComplete{Privilege: PrvTruncate},
+			GrantedOn:         ObjTpTable,
+		}: {},
+		GrantTemplate{
+			PrivilegeComplete: PrivilegeComplete{Privilege: PrvDelete},
+			GrantedOn:         ObjTpTable,
+		}: {},
+		GrantTemplate{
+			PrivilegeComplete: PrivilegeComplete{Privilege: PrvEvolveSchema},
+			GrantedOn:         ObjTpTable,
+		}: {},
+		GrantTemplate{
+			PrivilegeComplete: PrivilegeComplete{Privilege: PrvApplyBudget},
+			GrantedOn:         ObjTpTable,
 		}: {},
 	}
 

--- a/internal/snowflake/config.go
+++ b/internal/snowflake/config.go
@@ -2,6 +2,7 @@ package snowflake
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"strconv"
 	"strings"
@@ -152,8 +153,7 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 		}
 	}
 
-	cnf.DatabaseRolePrivileges = map[Mode]map[GrantTemplate]struct{}{}
-	cnf.DatabaseRolePrivileges[ModeRead] = map[GrantTemplate]struct{}{
+	cnf.ObjectPrivilegesRead = map[GrantTemplate]struct{}{
 		GrantTemplate{
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvUsage},
 			GrantedOn:         ObjTpDatabase,
@@ -179,41 +179,19 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 			GrantedOn:         ObjTpTable,
 		}: {},
 		GrantTemplate{
+			PrivilegeComplete: PrivilegeComplete{Privilege: PrvReferences},
+			GrantedOn:         ObjTpTable,
+		}: {},
+		GrantTemplate{
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvSelect},
 			GrantedOn:         ObjTpView,
 		}: {},
 		GrantTemplate{
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvReferences},
-			GrantedOn:         ObjTpTable,
-		}: {},
-		GrantTemplate{
-			PrivilegeComplete: PrivilegeComplete{Privilege: PrvReferences},
 			GrantedOn:         ObjTpView,
 		}: {},
 	}
-
-	cnf.ProductRolePrivileges = map[Mode]map[GrantTemplate]struct{}{}
-	cnf.ProductRolePrivileges[ModeRead] = map[GrantTemplate]struct{}{
-		GrantTemplate{
-			PrivilegeComplete:         PrivilegeComplete{Privilege: PrvUsage},
-			GrantedOn:                 ObjTpDatabaseRole,
-			GrantedRoleIsGruprManaged: util.NewTrue(),
-		}: {},
-		GrantTemplate{
-			PrivilegeComplete: PrivilegeComplete{Privilege: PrvUsage},
-			GrantedOn:         ObjTpWarehouse,
-		}: {},
-		GrantTemplate{
-			PrivilegeComplete: PrivilegeComplete{Privilege: PrvOperate},
-			GrantedOn:         ObjTpWarehouse,
-		}: {},
-	}
-	cnf.ProductRolePrivileges[ModeWrite] = map[GrantTemplate]struct{}{
-		GrantTemplate{
-			PrivilegeComplete:         PrivilegeComplete{Privilege: PrvUsage},
-			GrantedOn:                 ObjTpDatabaseRole,
-			GrantedRoleIsGruprManaged: util.NewTrue(),
-		}: {},
+	cnf.ObjectPrivilegesWrite = map[GrantTemplate]struct{}{
 		GrantTemplate{
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvCreate, CreateObjectType: ObjTpTable},
 			GrantedOn:         ObjTpSchema,
@@ -229,14 +207,6 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 		GrantTemplate{
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvOwnership},
 			GrantedOn:         ObjTpView,
-		}: {},
-		GrantTemplate{
-			PrivilegeComplete: PrivilegeComplete{Privilege: PrvUsage},
-			GrantedOn:         ObjTpWarehouse,
-		}: {},
-		GrantTemplate{
-			PrivilegeComplete: PrivilegeComplete{Privilege: PrvOperate},
-			GrantedOn:         ObjTpWarehouse,
 		}: {},
 		GrantTemplate{
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvInsert},
@@ -261,6 +231,41 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 		GrantTemplate{
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvApplyBudget},
 			GrantedOn:         ObjTpTable,
+		}: {},
+	}
+	cnf.ObjectPrivileges = map[GrantTemplate]struct{}{}
+	maps.Copy(cnf.ObjectPrivileges, cnf.ObjectPrivilegesWrite)
+	maps.Copy(cnf.ObjectPrivileges, cnf.ObjectPrivilegesRead)
+
+	cnf.ProductRolePrivileges = map[Mode]map[GrantTemplate]struct{}{}
+	cnf.ProductRolePrivileges[ModeRead] = map[GrantTemplate]struct{}{
+		GrantTemplate{
+			PrivilegeComplete:         PrivilegeComplete{Privilege: PrvUsage},
+			GrantedOn:                 ObjTpDatabaseRole,
+			GrantedRoleIsGruprManaged: util.NewTrue(),
+		}: {},
+		GrantTemplate{
+			PrivilegeComplete: PrivilegeComplete{Privilege: PrvUsage},
+			GrantedOn:         ObjTpWarehouse,
+		}: {},
+		GrantTemplate{
+			PrivilegeComplete: PrivilegeComplete{Privilege: PrvOperate},
+			GrantedOn:         ObjTpWarehouse,
+		}: {},
+	}
+	cnf.ProductRolePrivileges[ModeWrite] = map[GrantTemplate]struct{}{
+		GrantTemplate{
+			PrivilegeComplete:         PrivilegeComplete{Privilege: PrvUsage},
+			GrantedOn:                 ObjTpDatabaseRole,
+			GrantedRoleIsGruprManaged: util.NewTrue(),
+		}: {},
+		GrantTemplate{
+			PrivilegeComplete: PrivilegeComplete{Privilege: PrvUsage},
+			GrantedOn:         ObjTpWarehouse,
+		}: {},
+		GrantTemplate{
+			PrivilegeComplete: PrivilegeComplete{Privilege: PrvOperate},
+			GrantedOn:         ObjTpWarehouse,
 		}: {},
 	}
 

--- a/internal/snowflake/config.go
+++ b/internal/snowflake/config.go
@@ -235,6 +235,17 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 	maps.Copy(cnf.ObjectPrivileges, cnf.ObjectPrivilegesWrite)
 	maps.Copy(cnf.ObjectPrivileges, cnf.ObjectPrivilegesRead)
 
+	cnf.ComputePrivileges = map[GrantTemplate]struct{}{
+		GrantTemplate{
+			PrivilegeComplete: PrivilegeComplete{Privilege: PrvUsage},
+			GrantedOn:         ObjTpWarehouse,
+		}: {},
+		GrantTemplate{
+			PrivilegeComplete: PrivilegeComplete{Privilege: PrvOperate},
+			GrantedOn:         ObjTpWarehouse,
+		}: {},
+	}
+
 	cnf.ProductRolePrivileges = map[Mode]map[GrantTemplate]struct{}{}
 	cnf.ProductRolePrivileges[ModeRead] = map[GrantTemplate]struct{}{
 		GrantTemplate{

--- a/internal/snowflake/config.go
+++ b/internal/snowflake/config.go
@@ -30,6 +30,8 @@ type Config struct {
 	ObjectPrivilegesOwnership map[GrantTemplate]struct{}
 	ObjectPrivilegesWrite     map[GrantTemplate]struct{}
 	ObjectPrivileges          map[GrantTemplate]struct{}
+	ComputePrivileges         map[GrantTemplate]struct{}
+	DBRolePrivileges          map[GrantTemplate]struct{}
 	ManagedObjTypes           map[ObjType]bool
 	DryRun                    bool
 }
@@ -166,7 +168,7 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 		}
 	}
 
-	for ot := range []ObjType{ObjTpMaterializedView} {
+	for _, ot := range []ObjType{ObjTpMaterializedView} {
 		envStr := fmt.Sprintf("GRUPR_SNOWFLAKE_MA_%v", ot)
 		if env, ok := os.LookupEnv(envStr); ok {
 			if b, err := strconv.ParseBool(env); err != nil {

--- a/internal/snowflake/config.go
+++ b/internal/snowflake/config.go
@@ -164,8 +164,18 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 		}
 	}
 
+	for ot := range []ObjType{ObjTpMaterializedView} {
+		envStr := fmt.Sprintf("GRUPR_SNOWFLAKE_MA_%v", ot)
+		if env, ok := os.LookupEnv(envStr); ok {
+			if b, err := strconv.ParseBool(env); err != nil {
+				return nil, fmt.Errorf("%s: %w", envStr, err)
+			} else {
+				cnf.ManagedObjTypes[ot] = b
+			}
+		}
+	}
+
 	// These are the object privileges that are managed for read database roles
-	// TODO WIP: make privileges that are included depend on cnf.ManagedObjects
 	cnf.ObjectPrivilegesRead = map[GrantTemplate]struct{}{
 		GrantTemplate{
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvUsage},
@@ -203,15 +213,18 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvReferences},
 			GrantedOn:         ObjTpView,
 		}: {},
-		GrantTemplate{
-			PrivilegeComplete: PrivilegeComplete{Privilege: PrvSelect},
-			GrantedOn:         ObjTpMaterializedView,
-		}: {},
-		GrantTemplate{
+	}
+	if cnf.ManagedObjTypes[ObjTpMaterializedView] {
+		cnf.ObjectPrivilegesRead[GrantTemplate{
+				PrivilegeComplete: PrivilegeComplete{Privilege: PrvSelect},
+				GrantedOn:         ObjTpMaterializedView,
+		}] = {}
+		cnf.ObjectPrivilegesRead[GrantTemplate{
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvReferences},
 			GrantedOn:         ObjTpMaterializedView,
-		}: {},
+		}] = {}
 	}
+
 	// These are the object privileges that are managed for product write roles
 	cnf.ObjectPrivilegesOwnership = map[GrantTemplate]struct{}{
 		GrantTemplate{
@@ -234,11 +247,14 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvOwnership},
 			GrantedOn:         ObjTpView,
 		}: {},
-		GrantTemplate{
+	}
+	if cnf.ManagedObjTypes[ObjTpMaterializedView] {
+		cnf.ObjectPrivilegesOwnership[GrantTemplate{
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvOwnership},
 			GrantedOn:         ObjTpMaterializedView,
-		}: {},
+		}] = {}
 	}
+
 	// We need the next one to manage access exclusively,
 	// when we will revoke such privileges from any user managed or even system roles
 	cnf.ObjectPrivilegesWrite = map[GrantTemplate]struct{}{
@@ -266,11 +282,14 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvApplyBudget},
 			GrantedOn:         ObjTpTable,
 		}: {},
-		GrantTemplate{
+	}
+	if cnf.ManagedObjTypes[ObjTpMaterializedView] {
+		cnf.ObjectPrivilegesWrite[GrantTemplate{
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvApplyBudget},
 			GrantedOn:         ObjTpMaterializedView,
-		}: {},
+		}] = {}
 	}
+
 	// This one, too, will be used for managing access exclusively
 	cnf.ObjectPrivileges = map[GrantTemplate]struct{}{}
 	maps.Copy(cnf.ObjectPrivileges, cnf.ObjectPrivilegesRead)
@@ -278,10 +297,13 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 	maps.Copy(cnf.ObjectPrivileges, cnf.ObjectPrivilegesOwnership)
 
 	// These are compute privileges that are managed for product roles
-	// TODO: add MONITOR
 	cnf.ComputePrivileges = map[GrantTemplate]struct{}{
 		GrantTemplate{
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvUsage},
+			GrantedOn:         ObjTpWarehouse,
+		}: {},
+		GrantTemplate{
+			PrivilegeComplete: PrivilegeComplete{Privilege: PrvMonitor},
 			GrantedOn:         ObjTpWarehouse,
 		}: {},
 		GrantTemplate{
@@ -298,20 +320,13 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 		GrantTemplate{
 			PrivilegeComplete:         PrivilegeComplete{Privilege: PrvUsage},
 			GrantedOn:                 ObjTpDatabaseRole,
-			GrantedRoleIsGruprManaged: util.NewTrue(),
+			// Note that it's a bit odd that if we created another entry just like this, because it's a different
+			// pointer, it would be a different key in the map.
+			// TODO: use slices instead of maps for cnf.DBROlePrivileges and friends
+			GrantedRoleIsGruprManaged: util.NewTrue(), 
 		}: {},
 	}
 
-	for ot := range []ObjType{ObjTpMaterializedView} {
-		envStr := fmt.Sprintf("GRUPR_SNOWFLAKE_MA_%v", ot)
-		if env, ok := os.LookupEnv(envStr); ok {
-			if b, err := strconv.ParseBool(env); err != nil {
-				return nil, fmt.Errorf("%s: %w", envStr, err)
-			} else {
-				cnf.ManagedObjTypes[ot] = b
-			}
-		}
-	}
 
 	if dryRun, ok := os.LookupEnv("GRUPR_SNOWFLAKE_DRY_RUN"); ok {
 		if b, err := strconv.ParseBool(dryRun); err != nil {

--- a/internal/snowflake/config.go
+++ b/internal/snowflake/config.go
@@ -50,7 +50,14 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 			semantics.Ident("SECURITYADMIN"),
 			semantics.Ident("USERADMIN"),
 		},
-		ManagedObjTypes: map[ObjType]bool{},
+		// Later, we'll extend grupr with other object types, and when we do it and folks upgrade,
+		// we don't want grupr to all of a sudden claim management of all these other object types.
+		// So we build in a mechanism for people to explicity turn new object types on.
+		ManagedObjTypes: map[ObjType]bool{
+			ObjTpTable: true,
+			ObjTpHybridTable: true,
+			ObjTpView: true,
+		},
 		DryRun: true,
 	}
 
@@ -193,6 +200,14 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvReferences},
 			GrantedOn:         ObjTpView,
 		}: {},
+		GrantTemplate{
+			PrivilegeComplete: PrivilegeComplete{Privilege: PrvSelect},
+			GrantedOn:         ObjTpMaterializedView,
+		}: {},
+		GrantTemplate{
+			PrivilegeComplete: PrivilegeComplete{Privilege: PrvReferences},
+			GrantedOn:         ObjTpMaterializedView,
+		}: {},
 	}
 	// These are the object privileges that are managed for product write roles
 	cnf.ObjectPrivilegesOwnership = map[GrantTemplate]struct{}{
@@ -205,12 +220,20 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 			GrantedOn:         ObjTpSchema,
 		}: {},
 		GrantTemplate{
+			PrivilegeComplete: PrivilegeComplete{Privilege: PrvCreate, CreateObjectType: ObjTpMaterializedView},
+			GrantedOn:         ObjTpSchema,
+		}: {},
+		GrantTemplate{
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvOwnership},
 			GrantedOn:         ObjTpTable,
 		}: {},
 		GrantTemplate{
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvOwnership},
 			GrantedOn:         ObjTpView,
+		}: {},
+		GrantTemplate{
+			PrivilegeComplete: PrivilegeComplete{Privilege: PrvOwnership},
+			GrantedOn:         ObjTpMaterializedView,
 		}: {},
 	}
 	// We need the next one to manage access exclusively,
@@ -240,6 +263,10 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvApplyBudget},
 			GrantedOn:         ObjTpTable,
 		}: {},
+		GrantTemplate{
+			PrivilegeComplete: PrivilegeComplete{Privilege: PrvApplyBudget},
+			GrantedOn:         ObjTpMaterializedView,
+		}: {},
 	}
 	// This one, too, will be used for managing access exclusively
 	cnf.ObjectPrivileges = map[GrantTemplate]struct{}{}
@@ -248,6 +275,7 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 	maps.Copy(cnf.ObjectPrivileges, cnf.ObjectPrivilegesOwnership)
 
 	// These are compute privileges that are managed for product roles
+	// TODO: add MONITOR
 	cnf.ComputePrivileges = map[GrantTemplate]struct{}{
 		GrantTemplate{
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvUsage},
@@ -271,13 +299,13 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 		}: {},
 	}
 
-	for ot := range []ObjType{ObjTpTable, ObjTpView} {
+	for ot := range []ObjType{ObjTpMaterializedView} {
 		envStr := fmt.Sprintf("GRUPR_SNOWFLAKE_MA_%v", ot)
 		if env, ok := os.LookupEnv(envStr); ok {
 			if b, err := strconv.ParseBool(env); err != nil {
 				return nil, fmt.Errorf("%s: %w", envStr, err)
 			} else {
-				cnf.ManagedObjectTypes[ot] = b
+				cnf.ManagedObjTypes[ot] = b
 			}
 		}
 	}

--- a/internal/snowflake/config.go
+++ b/internal/snowflake/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	SystemDefinedRoles      []semantics.Ident
 	DatabaseRolePrivileges  map[Mode]map[GrantTemplate]struct{}
 	ProductRolePrivileges   map[Mode]map[GrantTemplate]struct{}
+	ManagedObjTypes         map[ObjType]bool
 	DryRun                  bool
 }
 
@@ -49,6 +50,7 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 			semantics.Ident("SECURITYADMIN"),
 			semantics.Ident("USERADMIN"),
 		},
+		ManagedObjTypes: map[ObjType]bool{},
 		DryRun: true,
 	}
 
@@ -267,6 +269,17 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvOperate},
 			GrantedOn:         ObjTpWarehouse,
 		}: {},
+	}
+
+	for ot := range []ObjType{ObjTpTable, ObjTpView} {
+		envStr := fmt.Sprintf("GRUPR_SNOWFLAKE_MA_%v", ot)
+		if env, ok := os.LookupEnv(envStr); ok {
+			if b, err := strconv.ParseBool(env); err != nil {
+				return nil, fmt.Errorf("%s: %w", envStr, err)
+			} else {
+				cnf.ManagedObjectTypes[ot] = b
+			}
+		}
 	}
 
 	if dryRun, ok := os.LookupEnv("GRUPR_SNOWFLAKE_DRY_RUN"); ok {

--- a/internal/snowflake/config.go
+++ b/internal/snowflake/config.go
@@ -155,6 +155,7 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 		}
 	}
 
+	// These are the object privileges that are managed for read database roles
 	cnf.ObjectPrivilegesRead = map[GrantTemplate]struct{}{
 		GrantTemplate{
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvUsage},
@@ -193,7 +194,8 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 			GrantedOn:         ObjTpView,
 		}: {},
 	}
-	cnf.ObjectPrivilegesWrite = map[GrantTemplate]struct{}{
+	// These are the object privileges that are managed for product write roles
+	cnf.ObjectPrivilegesOwnership = map[GrantTemplate]struct{}{
 		GrantTemplate{
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvCreate, CreateObjectType: ObjTpTable},
 			GrantedOn:         ObjTpSchema,
@@ -210,6 +212,10 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvOwnership},
 			GrantedOn:         ObjTpView,
 		}: {},
+	}
+	// We need the next one to manage access exclusively,
+	// when we will revoke such privileges from any user managed or even system roles
+	cnf.ObjectPrivilegesWrite = map[GrantTemplate]struct{}{
 		GrantTemplate{
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvInsert},
 			GrantedOn:         ObjTpTable,
@@ -235,10 +241,13 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 			GrantedOn:         ObjTpTable,
 		}: {},
 	}
+	// This one, too, will be used for managing access exclusively
 	cnf.ObjectPrivileges = map[GrantTemplate]struct{}{}
-	maps.Copy(cnf.ObjectPrivileges, cnf.ObjectPrivilegesWrite)
 	maps.Copy(cnf.ObjectPrivileges, cnf.ObjectPrivilegesRead)
+	maps.Copy(cnf.ObjectPrivileges, cnf.ObjectPrivilegesWrite)
+	maps.Copy(cnf.ObjectPrivileges, cnf.ObjectPrivilegesOwnership)
 
+	// These are compute privileges that are managed for product roles
 	cnf.ComputePrivileges = map[GrantTemplate]struct{}{
 		GrantTemplate{
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvUsage},
@@ -250,35 +259,15 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 		}: {},
 	}
 
-	cnf.ProductRolePrivileges = map[Mode]map[GrantTemplate]struct{}{}
-	cnf.ProductRolePrivileges[ModeRead] = map[GrantTemplate]struct{}{
+	// These are database role usage privileges which are managed for product roles
+	// The addition that the DB role should be grupr managed means that granting
+	// a non-grupr-managed DB role to a grupr managed product role is perfectly fine,
+	// it will be considered an unmanaged grant
+	cnf.DBRolePrivileges = map[GrantTemplate]struct{}{
 		GrantTemplate{
 			PrivilegeComplete:         PrivilegeComplete{Privilege: PrvUsage},
 			GrantedOn:                 ObjTpDatabaseRole,
 			GrantedRoleIsGruprManaged: util.NewTrue(),
-		}: {},
-		GrantTemplate{
-			PrivilegeComplete: PrivilegeComplete{Privilege: PrvUsage},
-			GrantedOn:         ObjTpWarehouse,
-		}: {},
-		GrantTemplate{
-			PrivilegeComplete: PrivilegeComplete{Privilege: PrvOperate},
-			GrantedOn:         ObjTpWarehouse,
-		}: {},
-	}
-	cnf.ProductRolePrivileges[ModeWrite] = map[GrantTemplate]struct{}{
-		GrantTemplate{
-			PrivilegeComplete:         PrivilegeComplete{Privilege: PrvUsage},
-			GrantedOn:                 ObjTpDatabaseRole,
-			GrantedRoleIsGruprManaged: util.NewTrue(),
-		}: {},
-		GrantTemplate{
-			PrivilegeComplete: PrivilegeComplete{Privilege: PrvUsage},
-			GrantedOn:         ObjTpWarehouse,
-		}: {},
-		GrantTemplate{
-			PrivilegeComplete: PrivilegeComplete{Privilege: PrvOperate},
-			GrantedOn:         ObjTpWarehouse,
 		}: {},
 	}
 

--- a/internal/snowflake/config.go
+++ b/internal/snowflake/config.go
@@ -157,10 +157,6 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 
 	cnf.ObjectPrivilegesRead = map[GrantTemplate]struct{}{
 		GrantTemplate{
-			PrivilegeComplete: PrivilegeComplete{Privilege: PrvUsage},
-			GrantedOn:         ObjTpDatabase,
-		}: {},
-		GrantTemplate{
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvMonitor},
 			GrantedOn:         ObjTpDatabase,
 		}: {},

--- a/internal/snowflake/config.go
+++ b/internal/snowflake/config.go
@@ -53,9 +53,11 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 		// Later, we'll extend grupr with other object types, and when we do it and folks upgrade,
 		// we don't want grupr to all of a sudden claim management of all these other object types.
 		// So we build in a mechanism for people to explicity turn new object types on.
+		//
+		// Note that ObjTpTable implies we also manage ObjTpHybridTable; in the output of SHOW GRANTS,
+		// and in SQL statements like CREATE <object_type> the two are not distinguished
 		ManagedObjTypes: map[ObjType]bool{
 			ObjTpTable: true,
-			ObjTpHybridTable: true,
 			ObjTpView: true,
 		},
 		DryRun: true,
@@ -163,6 +165,7 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 	}
 
 	// These are the object privileges that are managed for read database roles
+	// TODO WIP: make privileges that are included depend on cnf.ManagedObjects
 	cnf.ObjectPrivilegesRead = map[GrantTemplate]struct{}{
 		GrantTemplate{
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvUsage},

--- a/internal/snowflake/config.go
+++ b/internal/snowflake/config.go
@@ -12,35 +12,37 @@ import (
 )
 
 type Config struct {
-	User                    semantics.Ident
-	Role                    semantics.Ident
-	Account                 string
-	Database                semantics.Ident
-	Schema                  semantics.Ident
-	UseSQLOpen              bool
-	RSAKeyPath              string
-	MaxOpenConns            int
-	MaxIdleConns            int
-	MaxProductDTAPThreads   int
-	StmtBatchSize           int
-	MaxProductDTAPRefreshes int
-	Modes                   [1]Mode
-	SystemDefinedRoles      []semantics.Ident
-	DatabaseRolePrivileges  map[Mode]map[GrantTemplate]struct{}
-	ProductRolePrivileges   map[Mode]map[GrantTemplate]struct{}
-	ManagedObjTypes         map[ObjType]bool
-	DryRun                  bool
+	User                      semantics.Ident
+	Role                      semantics.Ident
+	Account                   string
+	Database                  semantics.Ident
+	Schema                    semantics.Ident
+	UseSQLOpen                bool
+	RSAKeyPath                string
+	MaxOpenConns              int
+	MaxIdleConns              int
+	MaxProductDTAPThreads     int
+	StmtBatchSize             int
+	MaxProductDTAPRefreshes   int
+	Modes                     [1]Mode
+	SystemDefinedRoles        []semantics.Ident
+	ObjectPrivilegesRead      map[GrantTemplate]struct{}
+	ObjectPrivilegesOwnership map[GrantTemplate]struct{}
+	ObjectPrivilegesWrite     map[GrantTemplate]struct{}
+	ObjectPrivileges          map[GrantTemplate]struct{}
+	ManagedObjTypes           map[ObjType]bool
+	DryRun                    bool
 }
 
 func GetConfig(semCnf *semantics.Config) (*Config, error) {
 	cnf := &Config{
-		UseSQLOpen:              false,
-		MaxOpenConns:            0, // unlimited
-		MaxIdleConns:            3, // MaxProductDTAPThreads - 1 (sometimes we use only one conn before quickly fanning out again)
-		MaxProductDTAPThreads:   4,
-		StmtBatchSize:           100,
-		MaxProductDTAPRefreshes: 4,
-		Modes:                   [1]Mode{ModeRead},
+		UseSQLOpen:                false,
+		MaxOpenConns:              0, // unlimited
+		MaxIdleConns:              3, // MaxProductDTAPThreads - 1 (sometimes we use only one conn before quickly fanning out again)
+		MaxProductDTAPThreads:     4,
+		StmtBatchSize:             100,
+		MaxProductDTAPRefreshes:   4,
+		Modes:                     [1]Mode{ModeRead},
 		SystemDefinedRoles: []semantics.Ident{
 			semantics.Ident("GLOBALORGADMIN"),
 			semantics.Ident("ORGADMIN"),
@@ -236,10 +238,6 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 			GrantedOn:         ObjTpSchema,
 		}: {},
 		GrantTemplate{
-			PrivilegeComplete: PrivilegeComplete{Privilege: PrvCreate, CreateObjectType: ObjTpMaterializedView},
-			GrantedOn:         ObjTpSchema,
-		}: {},
-		GrantTemplate{
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvOwnership},
 			GrantedOn:         ObjTpTable,
 		}: {},
@@ -249,6 +247,10 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 		}: {},
 	}
 	if cnf.ManagedObjTypes[ObjTpMaterializedView] {
+		cnf.ObjectPrivilegesOwnership[GrantTemplate{
+			PrivilegeComplete: PrivilegeComplete{Privilege: PrvCreate, CreateObjectType: ObjTpMaterializedView},
+			GrantedOn:         ObjTpSchema,
+		}] = {}
 		cnf.ObjectPrivilegesOwnership[GrantTemplate{
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvOwnership},
 			GrantedOn:         ObjTpMaterializedView,

--- a/internal/snowflake/config.go
+++ b/internal/snowflake/config.go
@@ -36,13 +36,13 @@ type Config struct {
 
 func GetConfig(semCnf *semantics.Config) (*Config, error) {
 	cnf := &Config{
-		UseSQLOpen:                false,
-		MaxOpenConns:              0, // unlimited
-		MaxIdleConns:              3, // MaxProductDTAPThreads - 1 (sometimes we use only one conn before quickly fanning out again)
-		MaxProductDTAPThreads:     4,
-		StmtBatchSize:             100,
-		MaxProductDTAPRefreshes:   4,
-		Modes:                     [1]Mode{ModeRead},
+		UseSQLOpen:              false,
+		MaxOpenConns:            0, // unlimited
+		MaxIdleConns:            3, // MaxProductDTAPThreads - 1 (sometimes we use only one conn before quickly fanning out again)
+		MaxProductDTAPThreads:   4,
+		StmtBatchSize:           100,
+		MaxProductDTAPRefreshes: 4,
+		Modes:                   [1]Mode{ModeRead},
 		SystemDefinedRoles: []semantics.Ident{
 			semantics.Ident("GLOBALORGADMIN"),
 			semantics.Ident("ORGADMIN"),
@@ -60,7 +60,7 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 		// and in SQL statements like CREATE <object_type> the two are not distinguished
 		ManagedObjTypes: map[ObjType]bool{
 			ObjTpTable: true,
-			ObjTpView: true,
+			ObjTpView:  true,
 		},
 		DryRun: true,
 	}
@@ -218,13 +218,13 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 	}
 	if cnf.ManagedObjTypes[ObjTpMaterializedView] {
 		cnf.ObjectPrivilegesRead[GrantTemplate{
-				PrivilegeComplete: PrivilegeComplete{Privilege: PrvSelect},
-				GrantedOn:         ObjTpMaterializedView,
-		}] = {}
+			PrivilegeComplete: PrivilegeComplete{Privilege: PrvSelect},
+			GrantedOn:         ObjTpMaterializedView,
+		}] = struct{}{}
 		cnf.ObjectPrivilegesRead[GrantTemplate{
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvReferences},
 			GrantedOn:         ObjTpMaterializedView,
-		}] = {}
+		}] = struct{}{}
 	}
 
 	// These are the object privileges that are managed for product write roles
@@ -250,11 +250,11 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 		cnf.ObjectPrivilegesOwnership[GrantTemplate{
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvCreate, CreateObjectType: ObjTpMaterializedView},
 			GrantedOn:         ObjTpSchema,
-		}] = {}
+		}] = struct{}{}
 		cnf.ObjectPrivilegesOwnership[GrantTemplate{
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvOwnership},
 			GrantedOn:         ObjTpMaterializedView,
-		}] = {}
+		}] = struct{}{}
 	}
 
 	// We need the next one to manage access exclusively,
@@ -289,7 +289,7 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 		cnf.ObjectPrivilegesWrite[GrantTemplate{
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvApplyBudget},
 			GrantedOn:         ObjTpMaterializedView,
-		}] = {}
+		}] = struct{}{}
 	}
 
 	// This one, too, will be used for managing access exclusively
@@ -320,15 +320,14 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 	// it will be considered an unmanaged grant
 	cnf.DBRolePrivileges = map[GrantTemplate]struct{}{
 		GrantTemplate{
-			PrivilegeComplete:         PrivilegeComplete{Privilege: PrvUsage},
-			GrantedOn:                 ObjTpDatabaseRole,
+			PrivilegeComplete: PrivilegeComplete{Privilege: PrvUsage},
+			GrantedOn:         ObjTpDatabaseRole,
 			// Note that it's a bit odd that if we created another entry just like this, because it's a different
 			// pointer, it would be a different key in the map.
 			// TODO: use slices instead of maps for cnf.DBROlePrivileges and friends
-			GrantedRoleIsGruprManaged: util.NewTrue(), 
+			GrantedRoleIsGruprManaged: util.NewTrue(),
 		}: {},
 	}
-
 
 	if dryRun, ok := os.LookupEnv("GRUPR_SNOWFLAKE_DRY_RUN"); ok {
 		if b, err := strconv.ParseBool(dryRun); err != nil {

--- a/internal/snowflake/config.go
+++ b/internal/snowflake/config.go
@@ -157,6 +157,10 @@ func GetConfig(semCnf *semantics.Config) (*Config, error) {
 
 	cnf.ObjectPrivilegesRead = map[GrantTemplate]struct{}{
 		GrantTemplate{
+			PrivilegeComplete: PrivilegeComplete{Privilege: PrvUsage},
+			GrantedOn:         ObjTpDatabase,
+		}: {},
+		GrantTemplate{
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvMonitor},
 			GrantedOn:         ObjTpDatabase,
 		}: {},

--- a/internal/snowflake/database_role.go
+++ b/internal/snowflake/database_role.go
@@ -108,7 +108,7 @@ func (r DatabaseRole) Create(ctx context.Context, cnf *Config, conn *sql.DB) err
 }
 
 func (r DatabaseRole) hasUnmanagedPrivileges(ctx context.Context, cnf *Config, conn *sql.DB) (bool, error) {
-	for _, err := range QueryGrantsToDBRoleFilteredLimit(ctx, cnf, conn, r.Database, r.Name, nil, cnf.DatabaseRolePrivileges[r.Mode], 1) {
+	for _, err := range QueryGrantsToDBRoleFilteredLimit(ctx, cnf, conn, r.Database, r.Name, nil, cnf.ObjectPrivilegesRead, 1) {
 		if err != nil {
 			return true, err
 		}

--- a/internal/snowflake/db_cache.go
+++ b/internal/snowflake/db_cache.go
@@ -77,9 +77,12 @@ func (c *dbCache) refreshSchemas(ctx context.Context, conn *sql.DB, db semantics
 	return nil
 }
 
-func (c *dbCache) refreshDBRoles(ctx context.Context, semCnf *semantics.Config, cnf *Config, conn *sql.DB, db semantics.Ident) error {
-	if err := GrantCreateDatabaseRoleToSelf(ctx, cnf, conn, db); err != nil {
-		return err
+func (c *dbCache) refreshDBRoles(ctx context.Context, semCnf *semantics.Config, cnf *Config, conn *sql.DB,
+	db semantics.Ident, grantCreateDBRole bool) error {
+	if grantCreateDBRole {
+		if err := GrantCreateDatabaseRoleToSelf(ctx, cnf, conn, db); err != nil {
+			return err
+		}
 	}
 	c.dbRoles = map[DatabaseRole]struct{}{} // overwrite if c.dbRoles already had a value
 	for r, err := range QueryDatabaseRoles(ctx, semCnf, cnf, conn, db) {

--- a/internal/snowflake/future_grant.go
+++ b/internal/snowflake/future_grant.go
@@ -91,16 +91,16 @@ func newFutureGrant(privilege string, createObjType string, grantedOn string, na
 	if _, err = r.Read(); err != io.EOF {
 		return g, err
 	} // more than one record
-	switch g.GrantedOn {
-	case ObjTpSchema:
+	switch len(rec) {
+	case 2:
+		g.GrantedIn = ObjTpDatabase
 		g.Database = semantics.Ident(rec[0])
-	case ObjTpTable, ObjTpView:
+	case 3:
+		g.GrantedIn = ObjTpSchema
 		g.Database = semantics.Ident(rec[0])
 		g.Schema = semantics.Ident(rec[1])
-	case ObjTpOther:
-		// We don't know how to interpret 'name' in this case.
 	default:
-		return g, fmt.Errorf("unsupported granted_on object type for future grant")
+		return g, fmt.Errorf("parsing name in future grant failed")
 	}
 	return g, nil
 }

--- a/internal/snowflake/future_grant.go
+++ b/internal/snowflake/future_grant.go
@@ -91,25 +91,13 @@ func newFutureGrant(privilege string, createObjType string, grantedOn string, na
 	if _, err = r.Read(); err != io.EOF {
 		return g, err
 	} // more than one record
-	switch len(rec) {
-	case 2:
-		g.GrantedIn = ObjTpDatabase
-		g.Database = semantics.Ident(rec[0])
-	case 3:
-		g.GrantedIn = ObjTpSchema
-		g.Database = semantics.Ident(rec[0])
-		g.Schema = semantics.Ident(rec[1])
-	default:
-		return g, fmt.Errorf("parsing name in future grant failed")
-	}
 	switch g.GrantedOn {
 	case ObjTpSchema:
 		g.Database = semantics.Ident(rec[0])
-		g.Schema = semantics.Ident(rec[1])
 	case ObjTpTable, ObjTpView:
 		g.Database = semantics.Ident(rec[0])
 		g.Schema = semantics.Ident(rec[1])
-		g.Object = semantics.Ident(rec[2])
+	case ObjTpOther:
 	default:
 		return g, fmt.Errorf("unsupported granted_on object type for future grant")
 	}

--- a/internal/snowflake/future_grant.go
+++ b/internal/snowflake/future_grant.go
@@ -76,7 +76,7 @@ func newFutureGrant(privilege string, createObjType string, grantedOn string, na
 	grantedToDatabase semantics.Ident, grantedToName semantics.Ident, grantOption bool) (FutureGrant, error) {
 	g := FutureGrant{
 		Privileges:        []PrivilegeComplete{ParsePrivilegeComplete(privilege, createObjType)},
-		GrantedOn:         ParseObjType(grantedOn),
+		GrantedOn:         ParseObjTypeFromRecord(grantedOn),
 		GrantedTo:         grantedTo,
 		GrantedToDatabase: grantedToDatabase,
 		GrantedToName:     grantedToName,

--- a/internal/snowflake/future_grant.go
+++ b/internal/snowflake/future_grant.go
@@ -98,6 +98,7 @@ func newFutureGrant(privilege string, createObjType string, grantedOn string, na
 		g.Database = semantics.Ident(rec[0])
 		g.Schema = semantics.Ident(rec[1])
 	case ObjTpOther:
+		// We don't know how to interpret 'name' in this case.
 	default:
 		return g, fmt.Errorf("unsupported granted_on object type for future grant")
 	}

--- a/internal/snowflake/grant.go
+++ b/internal/snowflake/grant.go
@@ -91,19 +91,8 @@ func newGrantToRole(privilege string, createObjType string, grantedOn string, na
 		GrantOption:               grantOption,
 		GrantedBy:                 grantedBy,
 	}
-	fpr := map[ObjType]int{
-		ObjTpAccount:      1,
-		ObjTpDatabase:     1,
-		ObjTpDatabaseRole: 2,
-		ObjTpRole:         1,
-		ObjTpSchema:       2,
-		ObjTpTable:        3,
-		ObjTpView:         3,
-		ObjTpWarehouse:    1,
-	}
 	r := csv.NewReader(strings.NewReader(name)) // handles quoted fields as they appear in name
 	r.Comma = '.'
-	r.FieldsPerRecord = fpr[g.GrantedOn]
 	rec, err := r.Read()
 	if err != nil {
 		return g, err
@@ -129,6 +118,8 @@ func newGrantToRole(privilege string, createObjType string, grantedOn string, na
 	case ObjTpWarehouse:
 		g.Object = semantics.Ident(rec[0])
 	case ObjTpOther:
+		// We don't know anything about how to interpret 'name',
+		// We'll just leave blanks in g.Database, g.Schema, g.Object, etc.
 	default:
 		return g, fmt.Errorf("unsupported granted_on object type for grant")
 	}

--- a/internal/snowflake/grant.go
+++ b/internal/snowflake/grant.go
@@ -111,7 +111,7 @@ func newGrantToRole(privilege string, createObjType string, grantedOn string, na
 	case ObjTpSchema:
 		g.Database = semantics.Ident(rec[0])
 		g.Schema = semantics.Ident(rec[1])
-	case ObjTpTable, ObjTpView:
+	case ObjTpTable, ObjTpView, ObjTpMaterializedView:
 		g.Database = semantics.Ident(rec[0])
 		g.Schema = semantics.Ident(rec[1])
 		g.Object = semantics.Ident(rec[2])

--- a/internal/snowflake/grant.go
+++ b/internal/snowflake/grant.go
@@ -83,7 +83,7 @@ func newGrantToRole(privilege string, createObjType string, grantedOn string, na
 	grantedToDatabase semantics.Ident, grantedToName semantics.Ident, grantOption bool, grantedBy semantics.Ident) (Grant, error) {
 	g := Grant{
 		Privileges:                []PrivilegeComplete{ParsePrivilegeComplete(privilege, createObjType)},
-		GrantedOn:                 ParseObjType(grantedOn),
+		GrantedOn:                 ParseObjTypeFromRecord(grantedOn),
 		GrantedRoleIsGruprManaged: grantedRoleIsGruprManaged,
 		GrantedTo:                 grantedTo,
 		GrantedToDatabase:         grantedToDatabase,

--- a/internal/snowflake/grant.go
+++ b/internal/snowflake/grant.go
@@ -128,6 +128,7 @@ func newGrantToRole(privilege string, createObjType string, grantedOn string, na
 		g.Object = semantics.Ident(rec[2])
 	case ObjTpWarehouse:
 		g.Object = semantics.Ident(rec[0])
+	case ObjTpOther:
 	default:
 		return g, fmt.Errorf("unsupported granted_on object type for grant")
 	}

--- a/internal/snowflake/grant_template.go
+++ b/internal/snowflake/grant_template.go
@@ -20,7 +20,7 @@ func (g GrantTemplate) buildSQLFilter() (string, int) {
 		}
 	}
 	if g.GrantedOn != ObjTpOther {
-		clauses = append(clauses, fmt.Sprintf("granted_on = '%v'", g.GrantedOn))
+		clauses = append(clauses, fmt.Sprintf("granted_on = '%s'", g.GrantedOn.RecordString()))
 	}
 	if (g.GrantedOn == ObjTpRole || g.GrantedOn == ObjTpDatabaseRole) && g.GrantedRoleIsGruprManaged != nil {
 		clauses = append(clauses, "granted_role_is_grupr_managed")

--- a/internal/snowflake/grupin.go
+++ b/internal/snowflake/grupin.go
@@ -278,12 +278,14 @@ func (g *Grupin) setDBRoleGrants(ctx context.Context, semCnf *semantics.Config, 
 			// - Read database roles of interfaces that pd consumes
 			if grantedDBRole.ProductID == pd.ProductID {
 				if grantedDBRole.InterfaceID != "" {
+					// A product is not allowed to consume its own interface
 					pd.revokeGrantFromProductRole(grant)
 					continue
 				}
 				// grantedDBRole.InterfaceID == ""
 				if dbObjs, ok := pd.Interface.aggAccountObjects.DBs[grant.Database]; ok {
 					dbObjs.isReadDBRoleGrantedToProductRole[pr.Mode.getIdx()] = true
+					pd.Interface.aggAccountObjects.DBs[grant.Database] = dbObjs // value semantics
 				} else if pd.Interface.ObjectMatchers.DisjointFromDB(grant.Database) {
 					pd.revokeGrantFromProductRole(grant)
 				}

--- a/internal/snowflake/grupin.go
+++ b/internal/snowflake/grupin.go
@@ -35,7 +35,14 @@ func NewGrupin(ctx context.Context, semCnf *semantics.Config, cnf *Config, conn 
 		}
 	}
 
-	if c, err := newAccountCache(ctx, semCnf, cnf, conn); err != nil {
+	// before we create the account cache, which will be populated with the databases straight away,
+	// we query which databases the grupr role already has been granted CREATE DATABASE ROLE in
+	managedDBs, err := r.getManagedDBs(ctx, cnf, conn)
+	if err != nil {
+		return r, err
+	}
+
+	if c, err := newAccountCache(ctx, semCnf, cnf, conn, managedDBs); err != nil {
 		return r, err
 	} else {
 		r.accountCache = c
@@ -51,6 +58,26 @@ func NewGrupin(ctx context.Context, semCnf *semantics.Config, cnf *Config, conn 
 	}
 
 	return r, nil
+}
+
+func (_ *Grupin) getManagedDBs(ctx context.Context, cnf *Config, conn *sql.DB) (map[semantics.Ident]bool, error) {
+	/*
+		We define this as a "method" of Grupin because it is related to the grupr role, of which there is just one,
+		just like there is just one grupin. The two are related, and it is a convenient namespace for this method.
+	*/
+	m := map[semantics.Ident]bool{}
+	for g, err := range QueryGrantsToRoleFiltered(ctx, cnf, conn, cnf.Role, map[GrantTemplate]struct{}{
+		GrantTemplate{
+			PrivilegeComplete: PrivilegeComplete{Privilege: PrvCreateDatabaseRole},
+			GrantedOn: ObjTpDatabase,
+		}: {},
+	}, nil) {
+		if err != nil {
+			return m, err
+		}
+		m[g.Database] = true
+	}
+	return m, nil
 }
 
 func (g *Grupin) setWarehouses(semCnf *semantics.Config, warehouses []WarehouseDecoded) error {

--- a/internal/snowflake/grupin.go
+++ b/internal/snowflake/grupin.go
@@ -68,7 +68,7 @@ func (_ *Grupin) getManagedDBs(ctx context.Context, cnf *Config, conn *sql.DB) (
 	m := map[semantics.Ident]bool{}
 	for g, err := range QueryGrantsToRoleFiltered(ctx, cnf, conn, cnf.Role, map[GrantTemplate]struct{}{
 		GrantTemplate{
-			PrivilegeComplete: PrivilegeComplete{Privilege: PrvCreateDatabaseRole},
+			PrivilegeComplete: PrivilegeComplete{Privilege: PrvCreate, CreateObjectType: ObjTpDatabaseRole},
 			GrantedOn: ObjTpDatabase,
 		}: {},
 	}, nil) {

--- a/internal/snowflake/grupin.go
+++ b/internal/snowflake/grupin.go
@@ -442,7 +442,7 @@ func (g *Grupin) setProductRoles(ctx context.Context, semCnf *semantics.Config, 
 		if err = rows.Scan(&roleName); err != nil {
 			return err
 		}
-		if r, err := newProductRoleFromString(semCnf, roleName); err != nil {
+		if r, err := newProductRoleFromIdent(semCnf, roleName); err != nil {
 			return err
 		} else {
 			g.productRoles[r] = struct{}{}

--- a/internal/snowflake/grupin.go
+++ b/internal/snowflake/grupin.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/rwberendsen/grupr/internal/semantics"
 	"github.com/rwberendsen/grupr/internal/syntax"
-	"github.com/rwberendsen/grupr/internal/util"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/internal/snowflake/grupin.go
+++ b/internal/snowflake/grupin.go
@@ -238,13 +238,7 @@ func (g *Grupin) setDBRoleGrants(ctx context.Context, semCnf *semantics.Config, 
 		if _, ok := g.productRoles[pr]; !ok && cnf.DryRun {
 			continue
 		}
-		for grant, err := range QueryGrantsToRoleFiltered(ctx, cnf, conn, pr.ID, map[GrantTemplate]struct{}{
-			GrantTemplate{
-				PrivilegeComplete:         PrivilegeComplete{Privilege: PrvUsage},
-				GrantedOn:                 ObjTpDatabaseRole,
-				GrantedRoleIsGruprManaged: util.NewTrue(),
-			}: {},
-		}, nil) {
+		for grant, err := range QueryGrantsToRoleFiltered(ctx, cnf, conn, pr.ID, cnf.DBRolePrivileges, nil) {
 			if err != nil {
 				return err
 			}

--- a/internal/snowflake/interface.go
+++ b/internal/snowflake/interface.go
@@ -136,9 +136,9 @@ func (i *Interface) setGrants(ctx context.Context, semCnf *semantics.Config, cnf
 	return nil
 }
 
-func (i *Interface) pushToDoFutureGrants(yield func(FutureGrant) bool) bool {
+func (i *Interface) pushToDoFutureGrants(yield func(FutureGrant) bool, mots map[ObjType]bool) bool {
 	for _, dbObjs := range i.aggAccountObjects.DBs {
-		if !dbObjs.pushToDoFutureGrants(yield) {
+		if !dbObjs.pushToDoFutureGrants(yield, mots) {
 			return false
 		}
 	}

--- a/internal/snowflake/obj.go
+++ b/internal/snowflake/obj.go
@@ -35,6 +35,14 @@ func QueryObjs(ctx context.Context, conn *sql.DB, db semantics.Ident, schema sem
 		// Because we apply filters, even if fewer results are returned, perhaps there are still more.
 		// For that reason, our last row has a count of the first query result
 		mayHaveMore := true
+		type objTpRec struct {
+			kind string
+			is_hybrid bool
+			is_dynamic bool
+			is_iceberg bool
+			is_interactive bool
+		}
+		toDetermine := map[string]objTpRec{}
 		var fromClause string
 		limit := 10000
 		for mayHaveMore {
@@ -43,12 +51,12 @@ SELECT
     NULL AS n
   , "name" AS name
   , "kind" AS kind
+  , "is_hybrid" AS is_hybrid
+  , "is_dynamic" AS is_dynamic
+  , "is_iceberg" AS is_iceberg
+  , "is_interactive" AS is_interactive
   , "owner" AS owner
 FROM $1
-WHERE kind in ('%s', '%s')
-AND "is_hybrid" = 'N'
-AND "is_dynamic" = 'N'
-AND "is_iceberg" = 'N'
 UNION ALL
 SELECT
     COUNT(*)
@@ -70,6 +78,10 @@ FROM $1
 				var n *int
 				var name semantics.Ident
 				var kind string
+				var is_hybrid string
+				var is_dynamic string
+				var is_iceberg string
+				var is_interactive string
 				var owner semantics.Ident
 				if err = rows.Scan(&n, &name, &kind, &owner); err != nil {
 					err = fmt.Errorf("QueryObjs: error scanning row: %w", err)
@@ -84,11 +96,18 @@ FROM $1
 					}
 					continue
 				}
-				if obj, err := newObj(name, ParseObjType(kind), owner); err != nil {
-					yield(Obj{}, err)
-					return
-				} else if !yield(obj, nil) {
-					return
+				if objType, ok := ParseObjTypeFromRecord(kind, is_hybrid, is_dynamic, is_iceberg, is_interactive); ok {
+					if !yield(Obj{Name: name, ObjectType: objType, Owner: owner}, nil) {
+							return
+					}
+				} else {
+					toDetermine[name] = objTpRec{
+						kind: kind,
+						is_hybrid: is_hybrid,
+						is_dynamic: is_dynamic,
+						is_iceberg: is_iceberg,
+						is_interactive: is_interactive,
+					}
 				}
 				lastName = name
 			}
@@ -97,6 +116,20 @@ FROM $1
 				yield(Obj{}, err)
 				return
 			}
+		}
+		if toDetermineHasViews() > 0 {
+			// There were objects for which we cannot decide the object type based on the output of SHOW OBJECTS 
+			// Still, we need to know the object type, to be able to manage grants correctly
+			// The only practical way appears to be to query again, for more specific object types. 
+			// In particular, when kind equals VIEW, we need to know if it is a regular view, a materialized view,
+			// or a semantic view. SHOW VIEWS does not appear to include semantic views.
+			// We may query specifically for MATERIALIZED VIEWS, and then SEMANTIC VIEWS.
+			// And, any remaining objects with kind VIEW we may assume to be regular views--until Snowflake introduces
+			// yet more view types without indicating so in SHOW OBJECTS its output
+			
+			// WIP: fire query for materialized views, and delete matching records from toDetermine
+			// WIP: if toDetermine still has views, fire query for semantic views, and delete matching records from toDetermine
+			// WIP: yield any remaining views in toDetermine as regular views
 		}
 	}
 }

--- a/internal/snowflake/obj.go
+++ b/internal/snowflake/obj.go
@@ -168,6 +168,28 @@ func GetObjs(ctx context.Context, conn *sql.DB, db semantics.Ident, schema seman
 	}
 }
 
+func queryTables(ctx context.Context, conn *sql.DB, db semantics.Ident, schema semantics.Ident) iter.Seq2[tableRec,
+	error] {
+	// The main problem with the SHOW TABLES function is that there is no flag "is_normal" for regular tables.
+	// If new types of tables are returned in the future, with flags like "is_new_type_X", "is_new_type_Y",
+	// grupr will treat it like a regular table. That means grupr may crash, for example, when it tries to
+	// grant SELECT ERROR TABLE, which, as of Apr 2026, is only applicable to normal tables.
+	// 
+	// Until Snowflake adds a flag "is_normal" to the output of the SHOW TABLES function (and friends like SHOW OBJECTS,
+	// SHOW VIEWS, etc, I see no easy way to prevent this problem, other than quickly fixing grupr each time Snowflake
+	// comes out with something new (again).
+}
+
+func queryViews(ctx context.Context, conn *sql.DB, db semantics.Ident, schema semantics.Ident) iter.Seq2[viewRec,
+	error] {
+	// The main problem with the SHOW VIEWS function is that there is no flag "is_normal" for regular views.
+	// If new types of views are returned in the future, with flags like "is_new_type_X", "is_new_type_Y",
+	// grupr will treat it like a regular view.
+	// Until Snowflake adds a flag "is_normal" to the output of the SHOW VIEWS function (and friends like SHOW OBJECTS,
+	// SHOW TABLES, etc, I see no easy way to prevent this problem, other than quickly fixing grupr each time Snowflake
+	// comes out with something new (again).
+}
+
 func queryObjs(ctx context.Context, conn *sql.DB, db semantics.Ident, schema semantics.Ident) iter.Seq2[objRec, error] {
 	// The problem with the SHOW OBJECTS function is that there is no flag "is_regular" for regular tables.
 	// If new types of tables are returned in the future, with flags like "is_new_type_X", "is_new_type_Y",

--- a/internal/snowflake/obj.go
+++ b/internal/snowflake/obj.go
@@ -39,9 +39,13 @@ func QueryObjs(ctx context.Context, conn *sql.DB, db semantics.Ident, schema sem
 SELECT
     NULL AS n
   , "name" AS name
-  , "kind" As kind
+  , "kind" AS kind
   , "owner" AS owner
-FROM $1 WHERE kind in ('%s', '%s')
+FROM $1
+WHERE kind in ('%s', '%s')
+AND "is_hybrid" = 'N'
+AND "is_dynamic" = 'N'
+AND "is_iceberg" = 'N'
 UNION ALL
 SELECT
     COUNT(*)

--- a/internal/snowflake/obj.go
+++ b/internal/snowflake/obj.go
@@ -16,6 +16,16 @@ type Obj struct {
 	Owner      semantics.Ident
 }
 
+type objRec struct {
+	name semantics.Ident
+	kind string
+	owner semantics.Ident
+	is_hybrid bool
+	is_dynamic bool
+	is_iceberg bool
+	is_interactive bool
+}
+
 func newObj(name semantics.Ident, objType ObjType, owner semantics.Ident) (Obj, error) {
 	if len(name) == 0 {
 		return Obj{}, fmt.Errorf("zero length identifier")
@@ -26,7 +36,72 @@ func newObj(name semantics.Ident, objType ObjType, owner semantics.Ident) (Obj, 
 	return Obj{Name: name, ObjectType: objType, Owner: owner}, nil
 }
 
-func QueryObjs(ctx context.Context, conn *sql.DB, db semantics.Ident, schema semantics.Ident) iter.Seq2[Obj, error] {
+func ParseObjTypeFromShowObjectsRecord(rec objRec) (ObjType, bool) {
+	switch rec.kind {
+	case "TABLE":
+		// TODO: there appears to be something like a dynamic iceberg table, for example, not sure how it would be
+		// represented here, and what would be the set of privileges we can assign an object like that, it is not
+		// separate treated in the Snowflake documentation page on access control privileges as of April 2026
+		if rec.is_hybrid && !rec.is_dynamic && !rec.is_iceberg && !rec.is_interactive {
+			return ObjTpHybridTable, true
+		}
+		if !rec.is_hybrid && rec.is_dynamic && !rec.is_iceberg && !rec.is_interactive {
+			return ObjTpDynamicTable, true
+		}
+		if !rec.is_hybrid && !rec.is_dynamic && rec.is_iceberg && !rec.is_interactive {
+			return ObjTpIcebergTable, true
+		}
+		if !rec.is_hybrid && !rec.is_dynamic && !rec.is_iceberg && rec.is_interactive {
+			return ObjTpInteractiveTable, true
+		}
+	case "ONLINE_FEATURE_TABLE":
+		return ObjTpOnlineFeatureTable, true
+	case "EVENT_TABLE": // TODO: validate this is how it appears in the output
+		return ObjTpEventTable, true
+	case "EXTERNAL_TABLE": // TODO: validate this is how it appears in the output
+		return ObjTpExternalTable, true
+	case "VIEW":
+		return ObjTpView, false // we cannot fully determine object type
+	}
+	return ObjTpOther, false
+}
+
+func GetObjs(ctx context.Context, conn *sql.DB, db semantics.Ident, schema semantics.Ident) iter.Seq2[Obj, error] {
+	return func(yield func(Obj, error) bool) {
+		toDetermine := map[string]objRec{}
+		for rec := range queryObjs(ctx, conn, db, schema) {
+				if objType, ok := ParseObjTypeFromRecord(kind, is_hybrid, is_dynamic, is_iceberg, is_interactive); ok {
+					if !yield(Obj{Name: name, ObjectType: objType, Owner: owner}, nil) {
+							return
+					}
+				} else {
+					toDetermine[name] = objRec{
+						kind: kind,
+						is_hybrid: is_hybrid,
+						is_dynamic: is_dynamic,
+						is_iceberg: is_iceberg,
+						is_interactive: is_interactive,
+					}
+				}
+		}
+		if toDetermineHasViews() > 0 {
+			// There were objects for which we cannot decide the object type based on the output of SHOW OBJECTS 
+			// Still, we need to know the object type, to be able to manage grants correctly
+			// The only practical way appears to be to query again, for more specific object types. 
+			// In particular, when kind equals VIEW, we need to know if it is a regular view, a materialized view,
+			// or a semantic view. SHOW VIEWS does not appear to include semantic views.
+			// We may query specifically for MATERIALIZED VIEWS, and then SEMANTIC VIEWS.
+			// And, any remaining objects with kind VIEW we may assume to be regular views--until Snowflake introduces
+			// yet more view types without indicating so in SHOW OBJECTS its output
+			
+			// WIP: fire query for materialized views, and delete matching records from toDetermine
+			// WIP: if toDetermine still has views, fire query for semantic views, and delete matching records from toDetermine
+			// WIP: yield any remaining views in toDetermine as regular views
+		}
+	}
+}
+
+func queryObjs(ctx context.Context, conn *sql.DB, db semantics.Ident, schema semantics.Ident) iter.Seq2[objRec, error] {
 	// The problem with the SHOW OBJECTS function is that there is no flag "is_regular" for regular tables.
 	// If new types of tables are returned in the future, with flags like "is_new_type_X", "is_new_type_Y",
 	// calling code will treat it like a regular table.
@@ -35,14 +110,6 @@ func QueryObjs(ctx context.Context, conn *sql.DB, db semantics.Ident, schema sem
 		// Because we apply filters, even if fewer results are returned, perhaps there are still more.
 		// For that reason, our last row has a count of the first query result
 		mayHaveMore := true
-		type objTpRec struct {
-			kind string
-			is_hybrid bool
-			is_dynamic bool
-			is_iceberg bool
-			is_interactive bool
-		}
-		toDetermine := map[string]objTpRec{}
 		var fromClause string
 		limit := 10000
 		for mayHaveMore {
@@ -62,6 +129,10 @@ SELECT
     COUNT(*)
   , '' AS name
   , '' AS kind
+  , FALSE AS is_hybrid
+  , FALSE AS is_dynamic
+  , FALSE AS is_iceberg
+  , FALSE AS is_interactive
   , '' AS owner
 FROM $1
 `, db, schema, limit, fromClause, ObjTpTable, ObjTpView))
@@ -76,14 +147,9 @@ FROM $1
 			var lastName semantics.Ident
 			for rows.Next() {
 				var n *int
-				var name semantics.Ident
-				var kind string
-				var is_hybrid string
-				var is_dynamic string
-				var is_iceberg string
-				var is_interactive string
-				var owner semantics.Ident
-				if err = rows.Scan(&n, &name, &kind, &owner); err != nil {
+				var rec objRec
+				if err = rows.Scan(&n, &rec.name, &rec.kind, &rec.is_hybrid, &rec.is_dynamic, &rec.is_iceberg,
+					&rec.is_interactive, &rec.owner); err != nil {
 					err = fmt.Errorf("QueryObjs: error scanning row: %w", err)
 					yield(Obj{}, err)
 					return
@@ -96,18 +162,8 @@ FROM $1
 					}
 					continue
 				}
-				if objType, ok := ParseObjTypeFromRecord(kind, is_hybrid, is_dynamic, is_iceberg, is_interactive); ok {
-					if !yield(Obj{Name: name, ObjectType: objType, Owner: owner}, nil) {
-							return
-					}
-				} else {
-					toDetermine[name] = objTpRec{
-						kind: kind,
-						is_hybrid: is_hybrid,
-						is_dynamic: is_dynamic,
-						is_iceberg: is_iceberg,
-						is_interactive: is_interactive,
-					}
+				if !yield(rec, nil) {
+					return
 				}
 				lastName = name
 			}
@@ -116,20 +172,6 @@ FROM $1
 				yield(Obj{}, err)
 				return
 			}
-		}
-		if toDetermineHasViews() > 0 {
-			// There were objects for which we cannot decide the object type based on the output of SHOW OBJECTS 
-			// Still, we need to know the object type, to be able to manage grants correctly
-			// The only practical way appears to be to query again, for more specific object types. 
-			// In particular, when kind equals VIEW, we need to know if it is a regular view, a materialized view,
-			// or a semantic view. SHOW VIEWS does not appear to include semantic views.
-			// We may query specifically for MATERIALIZED VIEWS, and then SEMANTIC VIEWS.
-			// And, any remaining objects with kind VIEW we may assume to be regular views--until Snowflake introduces
-			// yet more view types without indicating so in SHOW OBJECTS its output
-			
-			// WIP: fire query for materialized views, and delete matching records from toDetermine
-			// WIP: if toDetermine still has views, fire query for semantic views, and delete matching records from toDetermine
-			// WIP: yield any remaining views in toDetermine as regular views
 		}
 	}
 }

--- a/internal/snowflake/obj.go
+++ b/internal/snowflake/obj.go
@@ -26,22 +26,94 @@ type objRec struct {
 	is_interactive bool
 }
 
-func newObj(name semantics.Ident, objType ObjType, owner semantics.Ident) (Obj, error) {
-	if len(name) == 0 {
-		return Obj{}, fmt.Errorf("zero length identifier")
-	}
-	if objType != ObjTpTable && objType != ObjTpView {
-		panic("ObjTp not implemented")
-	}
-	return Obj{Name: name, ObjectType: objType, Owner: owner}, nil
-}
-
 func ParseObjTypeFromShowObjectsRecord(rec objRec) (ObjType, bool) {
-	switch rec.kind {
-	case "TABLE":
+	switch ot := ParseObjTypeFromRecord(rec.kind); ot {
+	case ObjTpTable:
 		// TODO: there appears to be something like a dynamic iceberg table, for example, not sure how it would be
 		// represented here, and what would be the set of privileges we can assign an object like that, it is not
 		// separate treated in the Snowflake documentation page on access control privileges as of April 2026
+		// For now, if we have a table with both is_dynamic and is_iceberg set to true, we would say we don't
+		// recognize this type of object, returning ObjTpOther, false
+		//
+		// How this will be treated, then, is we will keep it around in the accountObjs as ObjTpOther.
+		// Later, when we find a grant on this object (where it may say granted_on = TABLE), and, say
+		// we want to revoke this grant, then we would either:
+		// - find it in accountObjs as ObjTpOther: meaning we find we don't manage this type of table yet; and 
+		//   thus the grant is unmanaged, and we don't revoke it, we leave it.
+		// - not find it: if the object was created after we refreshed objects. In this case, at the moment,
+		//   we would actually revoke it. We may have to change this behaviour. If we did not find it, but
+		//   it is there according to the grant, we don't know the type of the object.
+		//
+		// But if we change that behaviour, we might also not keep the object around in accountObjs at all
+		// if it's a type we don't manage.
+		// But changing that behaviour could be expensive though. Remember if we want to revoke it,
+		// in many cases that means it's not matched in the YAML of this product. So we would not find any
+		// of those in the accountobjs of the present product. And thus we would revoke hardly anything.
+		//
+		// So perhaps, rather than checking the accountObjs, we could be checking the accountCache directly,
+		// which has all objects we found while looking for all objects simultaneously. Then, if we don't
+		// find it, it means
+		// - it was created after we checked; we can leave the grant intact; next run it will be addressed; OR
+		// - it was already there, but we did not collect / recognize it during our querying for objects; it's not a
+		// type we support; OR
+		// - it does not match the YAML of any product. 
+		// Is there a single action that is always correct here?
+		// We don't want to revoke grants that sysadmins did on objects, not even if the objects are not matched by any
+		// YAML.
+		// 
+		// But we do want to revoke if this is a privilege within the scope of grupr. That would mean both the
+		// privilege and the object type fall within grupr it's scope.
+		//
+		// It seems that there is no way to dodge the necessity to follow up on revoke candidates: go back and
+		// query what the object type is, check if it's an object type that grupr is normally managing.
+		//
+		// Revoking privileges on objects is done per product-dtap, in parallel. So it makes sense to turn to
+		// the account cache again.
+		//
+		// After processing grants, we have a rough idea of object type (granted_on = TABLE) still can mean
+		// many things. When we get to the revoking part, we can find all the schema's that have objects to
+		// revoke, and create matching expressions perhaps; since they may be schema's that are not even
+		// in the YAML for any product, and thus they may or may not be in the accountcache. We could of
+		// course check if a revoke candidate is disjoint from the grupin or not. If it is, we could create
+		// a new matching expression to find the info. More precisely, if the schema is disjoint from the
+		// grupin, then we would have never collected the objects in that schema. Then we would need to
+		// to match it. But if it is not disjoint, then it means we did already query objects in that schema.
+		// In that case, we could work with potentially stale data, concluding that if the object is not
+		// in the account cache, we can leave it for a later grupr run. And if the object is there, we
+		// can learn about its type, check if we manage that type normally, and if so, revoke the privilege.
+		// If we had created a new matching expression, what happens here, we need a matchedAccountObjs
+		// object, and then we can just locate the object(s) in that one, and act accordingly.
+		// Well, looking at the account cache again, we don't have to check beforehand if the objects
+		// are there already or not, if the schema is disjoint from the YAML or not. We can just go in
+		// there with a version of 0. If the accountcache has a newer version, we'll take it without
+		// a query to Snowflake. If we match a database or schema that was never matched until now by
+		// any matching expression, then it will result in a query, as expected.
+		// The same goes for transferring ownership.
+		//
+		// In this case, if the object is not of a type we normally manage, we could leave it out of the
+		// accountObjs and friends. Then, if we don't find it, it can mean only that it was created after
+		// we last checked, or, it is not a type we support (yet).
+		// Alternatively, at the cost of some memory storage, we could keep it in accountobjs and friends,
+		// and then we can log a more descriptive message on why we are not revoking a particular grant.
+		// But if we go that, far, we might as well support it.
+		//
+		// So now I have to make a somewhat harder change, but, after that, I will be able to support
+		// new fancy Snowflake object types when I want, and grupr can work correctly within its scope
+		// always. The only caveat to that is that Snowflake makes it hard to identify "normal" tables.
+		// They can introduce a new flag is_super_hip, and they may decide to use "TABLE" for the "kind"
+		// column. I don't know about that flag, and I assume the table is normal, when in fact it is not.
+		// In that case I will treat it like a normal table, and may end up attempting to grant privileges
+		// that are not supported by super hip tables, in which case grupr will just crash. But that would
+		// hardly be grupr it's problem.
+		//
+		// A technical thing is that we have no way yet of querying the account cache while indicating you
+		// are not interested in writing, not even potentially. But that should be solvable.
+
+		// We should also think about temporary tables: grants on those objects may pop up as well
+		// we should probably leave them intact, cause grupr does not manage grants on temporary tables
+		// so that means then that if we do not find a granted object in the account cache, then we leave
+		// the grant intact. If we do find it and the object type is something grupr normally manages,
+		// then we revoke.
 		if rec.is_hybrid && !rec.is_dynamic && !rec.is_iceberg && !rec.is_interactive {
 			return ObjTpHybridTable, true
 		}
@@ -54,33 +126,20 @@ func ParseObjTypeFromShowObjectsRecord(rec objRec) (ObjType, bool) {
 		if !rec.is_hybrid && !rec.is_dynamic && !rec.is_iceberg && rec.is_interactive {
 			return ObjTpInteractiveTable, true
 		}
-	case "ONLINE_FEATURE_TABLE":
-		return ObjTpOnlineFeatureTable, true
-	case "EVENT_TABLE": // TODO: validate this is how it appears in the output
-		return ObjTpEventTable, true
-	case "EXTERNAL_TABLE": // TODO: validate this is how it appears in the output
-		return ObjTpExternalTable, true
-	case "VIEW":
-		return ObjTpView, false // we cannot fully determine object type
+	case ObjTpView:
+		return ObjTpView, false // we cannot fully determine object type based on SHOW OBJECTS output
+	default:
+		return ot, true
 	}
-	return ObjTpOther, false
 }
 
 func GetObjs(ctx context.Context, conn *sql.DB, db semantics.Ident, schema semantics.Ident) iter.Seq2[Obj, error] {
 	return func(yield func(Obj, error) bool) {
-		toDetermine := map[string]objRec{}
+		// First, query table-like objects
 		for rec := range queryObjs(ctx, conn, db, schema) {
-				if objType, ok := ParseObjTypeFromRecord(kind, is_hybrid, is_dynamic, is_iceberg, is_interactive); ok {
-					if !yield(Obj{Name: name, ObjectType: objType, Owner: owner}, nil) {
+				if ot, ok := ParseObjTypeFromShowObjectsRecord(rec); ok {
+					if !yield(Obj{Name: name, ObjectType: ot, Owner: owner}, nil) {
 							return
-					}
-				} else {
-					toDetermine[name] = objRec{
-						kind: kind,
-						is_hybrid: is_hybrid,
-						is_dynamic: is_dynamic,
-						is_iceberg: is_iceberg,
-						is_interactive: is_interactive,
 					}
 				}
 		}
@@ -89,10 +148,18 @@ func GetObjs(ctx context.Context, conn *sql.DB, db semantics.Ident, schema seman
 			// Still, we need to know the object type, to be able to manage grants correctly
 			// The only practical way appears to be to query again, for more specific object types. 
 			// In particular, when kind equals VIEW, we need to know if it is a regular view, a materialized view,
-			// or a semantic view. SHOW VIEWS does not appear to include semantic views.
+			// or a semantic view. (SHOW VIEWS does not appear to include semantic views, but SHOW OBJECTS should).
 			// We may query specifically for MATERIALIZED VIEWS, and then SEMANTIC VIEWS.
 			// And, any remaining objects with kind VIEW we may assume to be regular views--until Snowflake introduces
 			// yet more view types without indicating so in SHOW OBJECTS its output
+			// Oh boy, SHOW MATERIALIZED VIEWS does not offer paging beyond 10K results, unlike SHOW VIEWS.
+			// Inconsistencies, inconsistencies. SHOW SEMANTIC VIEWS does support paging, but it does not include
+			// semantic views; at least, it does not say so in the docs.
+			// So I guess we could use SHOW VIEWS to identify >10K materialized views, we'd have to filter out the
+			// SN_bla_bla Snowpark objects. We'd then have to separately query SEMANTIC VIEWS still, if we wanted to
+			// support those, too. If we query SHOW VIEWS, then it makes sense not to query them with SHOW OBJECTS at
+			// all, actually.
+			// And once we get there, it may make more sense to use SHOW TABLES, where we get a bit more flags as well.
 			
 			// WIP: fire query for materialized views, and delete matching records from toDetermine
 			// WIP: if toDetermine still has views, fire query for semantic views, and delete matching records from toDetermine
@@ -124,6 +191,7 @@ SELECT
   , "is_interactive" AS is_interactive
   , "owner" AS owner
 FROM $1
+WHERE kind = '%s'
 UNION ALL
 SELECT
     COUNT(*)
@@ -135,7 +203,7 @@ SELECT
   , FALSE AS is_interactive
   , '' AS owner
 FROM $1
-`, db, schema, limit, fromClause, ObjTpTable, ObjTpView))
+`, db, schema, limit, fromClause, ObjTpTable))
 			if err != nil {
 				if strings.Contains(err.Error(), "390201") { // ErrObjectNotExistOrAuthorized; this way of testing error code is used in errors_test in the gosnowflake repo
 					err = ErrObjectNotExistOrAuthorized

--- a/internal/snowflake/obj.go
+++ b/internal/snowflake/obj.go
@@ -27,6 +27,9 @@ func newObj(name semantics.Ident, objType ObjType, owner semantics.Ident) (Obj, 
 }
 
 func QueryObjs(ctx context.Context, conn *sql.DB, db semantics.Ident, schema semantics.Ident) iter.Seq2[Obj, error] {
+	// The problem with the SHOW OBJECTS function is that there is no flag "is_regular" for regular tables.
+	// If new types of tables are returned in the future, with flags like "is_new_type_X", "is_new_type_Y",
+	// calling code will treat it like a regular table.
 	return func(yield func(Obj, error) bool) {
 		// When there are more than 10K results, paginate.
 		// Because we apply filters, even if fewer results are returned, perhaps there are still more.

--- a/internal/snowflake/obj.go
+++ b/internal/snowflake/obj.go
@@ -16,129 +16,11 @@ type Obj struct {
 	Owner      semantics.Ident
 }
 
-type objRec struct {
-	name semantics.Ident
-	kind string
-	owner semantics.Ident
-	is_hybrid bool
-	is_dynamic bool
-	is_iceberg bool
-	is_interactive bool
-}
-
-func ParseObjTypeFromShowObjectsRecord(rec objRec) (ObjType, bool) {
-	switch ot := ParseObjTypeFromRecord(rec.kind); ot {
-	case ObjTpTable:
-		// TODO: there appears to be something like a dynamic iceberg table, for example, not sure how it would be
-		// represented here, and what would be the set of privileges we can assign an object like that, it is not
-		// separate treated in the Snowflake documentation page on access control privileges as of April 2026
-		// For now, if we have a table with both is_dynamic and is_iceberg set to true, we would say we don't
-		// recognize this type of object, returning ObjTpOther, false
-		//
-		// How this will be treated, then, is we will keep it around in the accountObjs as ObjTpOther.
-		// Later, when we find a grant on this object (where it may say granted_on = TABLE), and, say
-		// we want to revoke this grant, then we would either:
-		// - find it in accountObjs as ObjTpOther: meaning we find we don't manage this type of table yet; and 
-		//   thus the grant is unmanaged, and we don't revoke it, we leave it.
-		// - not find it: if the object was created after we refreshed objects. In this case, at the moment,
-		//   we would actually revoke it. We may have to change this behaviour. If we did not find it, but
-		//   it is there according to the grant, we don't know the type of the object.
-		//
-		// But if we change that behaviour, we might also not keep the object around in accountObjs at all
-		// if it's a type we don't manage.
-		// But changing that behaviour could be expensive though. Remember if we want to revoke it,
-		// in many cases that means it's not matched in the YAML of this product. So we would not find any
-		// of those in the accountobjs of the present product. And thus we would revoke hardly anything.
-		//
-		// So perhaps, rather than checking the accountObjs, we could be checking the accountCache directly,
-		// which has all objects we found while looking for all objects simultaneously. Then, if we don't
-		// find it, it means
-		// - it was created after we checked; we can leave the grant intact; next run it will be addressed; OR
-		// - it was already there, but we did not collect / recognize it during our querying for objects; it's not a
-		// type we support; OR
-		// - it does not match the YAML of any product. 
-		// Is there a single action that is always correct here?
-		// We don't want to revoke grants that sysadmins did on objects, not even if the objects are not matched by any
-		// YAML.
-		// 
-		// But we do want to revoke if this is a privilege within the scope of grupr. That would mean both the
-		// privilege and the object type fall within grupr it's scope.
-		//
-		// It seems that there is no way to dodge the necessity to follow up on revoke candidates: go back and
-		// query what the object type is, check if it's an object type that grupr is normally managing.
-		//
-		// Revoking privileges on objects is done per product-dtap, in parallel. So it makes sense to turn to
-		// the account cache again.
-		//
-		// After processing grants, we have a rough idea of object type (granted_on = TABLE) still can mean
-		// many things. When we get to the revoking part, we can find all the schema's that have objects to
-		// revoke, and create matching expressions perhaps; since they may be schema's that are not even
-		// in the YAML for any product, and thus they may or may not be in the accountcache. We could of
-		// course check if a revoke candidate is disjoint from the grupin or not. If it is, we could create
-		// a new matching expression to find the info. More precisely, if the schema is disjoint from the
-		// grupin, then we would have never collected the objects in that schema. Then we would need to
-		// to match it. But if it is not disjoint, then it means we did already query objects in that schema.
-		// In that case, we could work with potentially stale data, concluding that if the object is not
-		// in the account cache, we can leave it for a later grupr run. And if the object is there, we
-		// can learn about its type, check if we manage that type normally, and if so, revoke the privilege.
-		// If we had created a new matching expression, what happens here, we need a matchedAccountObjs
-		// object, and then we can just locate the object(s) in that one, and act accordingly.
-		// Well, looking at the account cache again, we don't have to check beforehand if the objects
-		// are there already or not, if the schema is disjoint from the YAML or not. We can just go in
-		// there with a version of 0. If the accountcache has a newer version, we'll take it without
-		// a query to Snowflake. If we match a database or schema that was never matched until now by
-		// any matching expression, then it will result in a query, as expected.
-		// The same goes for transferring ownership.
-		//
-		// In this case, if the object is not of a type we normally manage, we could leave it out of the
-		// accountObjs and friends. Then, if we don't find it, it can mean only that it was created after
-		// we last checked, or, it is not a type we support (yet).
-		// Alternatively, at the cost of some memory storage, we could keep it in accountobjs and friends,
-		// and then we can log a more descriptive message on why we are not revoking a particular grant.
-		// But if we go that, far, we might as well support it.
-		//
-		// So now I have to make a somewhat harder change, but, after that, I will be able to support
-		// new fancy Snowflake object types when I want, and grupr can work correctly within its scope
-		// always. The only caveat to that is that Snowflake makes it hard to identify "normal" tables.
-		// They can introduce a new flag is_super_hip, and they may decide to use "TABLE" for the "kind"
-		// column. I don't know about that flag, and I assume the table is normal, when in fact it is not.
-		// In that case I will treat it like a normal table, and may end up attempting to grant privileges
-		// that are not supported by super hip tables, in which case grupr will just crash. But that would
-		// hardly be grupr it's problem.
-		//
-		// A technical thing is that we have no way yet of querying the account cache while indicating you
-		// are not interested in writing, not even potentially. But that should be solvable.
-
-		// We should also think about temporary tables: grants on those objects may pop up as well
-		// we should probably leave them intact, cause grupr does not manage grants on temporary tables
-		// so that means then that if we do not find a granted object in the account cache, then we leave
-		// the grant intact. If we do find it and the object type is something grupr normally manages,
-		// then we revoke.
-		if rec.is_hybrid && !rec.is_dynamic && !rec.is_iceberg && !rec.is_interactive {
-			return ObjTpHybridTable, true
-		}
-		if !rec.is_hybrid && rec.is_dynamic && !rec.is_iceberg && !rec.is_interactive {
-			return ObjTpDynamicTable, true
-		}
-		if !rec.is_hybrid && !rec.is_dynamic && rec.is_iceberg && !rec.is_interactive {
-			return ObjTpIcebergTable, true
-		}
-		if !rec.is_hybrid && !rec.is_dynamic && !rec.is_iceberg && rec.is_interactive {
-			return ObjTpInteractiveTable, true
-		}
-	case ObjTpView:
-		return ObjTpView, false // we cannot fully determine object type based on SHOW OBJECTS output
-	default:
-		return ot, true
-	}
-}
-
 func GetObjs(ctx context.Context, conn *sql.DB, db semantics.Ident, schema semantics.Ident) iter.Seq2[Obj, error] {
 	return func(yield func(Obj, error) bool) {
-		// First, query table-like objects
-		for rec := range queryObjs(ctx, conn, db, schema) {
-				if ot, ok := ParseObjTypeFromShowObjectsRecord(rec); ok {
-					if !yield(Obj{Name: name, ObjectType: ot, Owner: owner}, nil) {
+		for rec := range queryTables(ctx, conn, db, schema) {
+				if ot := rec.getObjType() ; ot != ObjTpOther {
+					if !yield(Obj{Name: rec.name, ObjectType: ot, Owner: rec.owner}, nil) {
 							return
 					}
 				}
@@ -166,18 +48,6 @@ func GetObjs(ctx context.Context, conn *sql.DB, db semantics.Ident, schema seman
 			// WIP: yield any remaining views in toDetermine as regular views
 		}
 	}
-}
-
-func queryTables(ctx context.Context, conn *sql.DB, db semantics.Ident, schema semantics.Ident) iter.Seq2[tableRec,
-	error] {
-	// The main problem with the SHOW TABLES function is that there is no flag "is_normal" for regular tables.
-	// If new types of tables are returned in the future, with flags like "is_new_type_X", "is_new_type_Y",
-	// grupr will treat it like a regular table. That means grupr may crash, for example, when it tries to
-	// grant SELECT ERROR TABLE, which, as of Apr 2026, is only applicable to normal tables.
-	// 
-	// Until Snowflake adds a flag "is_normal" to the output of the SHOW TABLES function (and friends like SHOW OBJECTS,
-	// SHOW VIEWS, etc, I see no easy way to prevent this problem, other than quickly fixing grupr each time Snowflake
-	// comes out with something new (again).
 }
 
 func queryViews(ctx context.Context, conn *sql.DB, db semantics.Ident, schema semantics.Ident) iter.Seq2[viewRec,

--- a/internal/snowflake/obj.go
+++ b/internal/snowflake/obj.go
@@ -16,19 +16,19 @@ type Obj struct {
 	Owner      semantics.Ident
 }
 
-func GetObjs(ctx context.Context, conn *sql.DB, db semantics.Ident, schema semantics.Ident, map[ObjType]bool mots) iter.Seq2[Obj, error] {
+func GetObjs(ctx context.Context, conn *sql.DB, db semantics.Ident, schema semantics.Ident, mots map[ObjType]bool) iter.Seq2[Obj, error] {
 	return func(yield func(Obj, error) bool) {
 		for rec := range queryTables(ctx, conn, db, schema) {
 			if ot := rec.getObjType(mots); ot != ObjTpOther {
 				if !yield(Obj{Name: rec.name, ObjectType: ot, Owner: rec.owner}, nil) {
-						return
+					return
 				}
 			}
 		}
 		for rec := range queryViews(ctx, conn, db, schema) {
 			if ot := rec.getObjType(mots); ot != ObjTpOther {
 				if !yield(Obj{Name: rec.name, ObjectType: ot, Owner: rec.owner}, nil) {
-						return
+					return
 				}
 			}
 		}

--- a/internal/snowflake/obj.go
+++ b/internal/snowflake/obj.go
@@ -3,9 +3,7 @@ package snowflake
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"iter"
-	"strings"
 
 	"github.com/rwberendsen/grupr/internal/semantics"
 )
@@ -16,7 +14,7 @@ type Obj struct {
 	Owner      semantics.Ident
 }
 
-func GetObjs(ctx context.Context, conn *sql.DB, db semantics.Ident, schema semantics.Ident, mots map[ObjType]bool) iter.Seq2[Obj, error] {
+func QueryObjs(ctx context.Context, conn *sql.DB, db semantics.Ident, schema semantics.Ident, mots map[ObjType]bool) iter.Seq2[Obj, error] {
 	return func(yield func(Obj, error) bool) {
 		for rec := range queryTables(ctx, conn, db, schema) {
 			if ot := rec.getObjType(mots); ot != ObjTpOther {

--- a/internal/snowflake/obj.go
+++ b/internal/snowflake/obj.go
@@ -16,7 +16,7 @@ type Obj struct {
 	Owner      semantics.Ident
 }
 
-func GetObjs(ctx context.Context, conn *sql.DB, db semantics.Ident, schema semantics.Ident) iter.Seq2[Obj, error] {
+func GetObjs(ctx context.Context, conn *sql.DB, db semantics.Ident, schema semantics.Ident, map[ObjType]bool mots) iter.Seq2[Obj, error] {
 	// TODO WIP: only get objects for types in cnf.ManagedObjects
 	return func(yield func(Obj, error) bool) {
 		for rec := range queryTables(ctx, conn, db, schema) {

--- a/internal/snowflake/obj.go
+++ b/internal/snowflake/obj.go
@@ -17,17 +17,16 @@ type Obj struct {
 }
 
 func GetObjs(ctx context.Context, conn *sql.DB, db semantics.Ident, schema semantics.Ident, map[ObjType]bool mots) iter.Seq2[Obj, error] {
-	// TODO WIP: only get objects for types in cnf.ManagedObjects
 	return func(yield func(Obj, error) bool) {
 		for rec := range queryTables(ctx, conn, db, schema) {
-			if ot := rec.getObjType(); ot != ObjTpOther {
+			if ot := rec.getObjType(mots); ot != ObjTpOther {
 				if !yield(Obj{Name: rec.name, ObjectType: ot, Owner: rec.owner}, nil) {
 						return
 				}
 			}
 		}
 		for rec := range queryViews(ctx, conn, db, schema) {
-			if ot := rec.getObjType(); ot != ObjTpOther {
+			if ot := rec.getObjType(mots); ot != ObjTpOther {
 				if !yield(Obj{Name: rec.name, ObjectType: ot, Owner: rec.owner}, nil) {
 						return
 				}

--- a/internal/snowflake/obj.go
+++ b/internal/snowflake/obj.go
@@ -17,6 +17,7 @@ type Obj struct {
 }
 
 func GetObjs(ctx context.Context, conn *sql.DB, db semantics.Ident, schema semantics.Ident) iter.Seq2[Obj, error] {
+	// TODO WIP: only get objects for types in cnf.ManagedObjects
 	return func(yield func(Obj, error) bool) {
 		for rec := range queryTables(ctx, conn, db, schema) {
 			if ot := rec.getObjType(); ot != ObjTpOther {

--- a/internal/snowflake/obj.go
+++ b/internal/snowflake/obj.go
@@ -19,118 +19,17 @@ type Obj struct {
 func GetObjs(ctx context.Context, conn *sql.DB, db semantics.Ident, schema semantics.Ident) iter.Seq2[Obj, error] {
 	return func(yield func(Obj, error) bool) {
 		for rec := range queryTables(ctx, conn, db, schema) {
-				if ot := rec.getObjType() ; ot != ObjTpOther {
-					if !yield(Obj{Name: rec.name, ObjectType: ot, Owner: rec.owner}, nil) {
-							return
-					}
+			if ot := rec.getObjType(); ot != ObjTpOther {
+				if !yield(Obj{Name: rec.name, ObjectType: ot, Owner: rec.owner}, nil) {
+						return
 				}
-		}
-		if toDetermineHasViews() > 0 {
-			// There were objects for which we cannot decide the object type based on the output of SHOW OBJECTS 
-			// Still, we need to know the object type, to be able to manage grants correctly
-			// The only practical way appears to be to query again, for more specific object types. 
-			// In particular, when kind equals VIEW, we need to know if it is a regular view, a materialized view,
-			// or a semantic view. (SHOW VIEWS does not appear to include semantic views, but SHOW OBJECTS should).
-			// We may query specifically for MATERIALIZED VIEWS, and then SEMANTIC VIEWS.
-			// And, any remaining objects with kind VIEW we may assume to be regular views--until Snowflake introduces
-			// yet more view types without indicating so in SHOW OBJECTS its output
-			// Oh boy, SHOW MATERIALIZED VIEWS does not offer paging beyond 10K results, unlike SHOW VIEWS.
-			// Inconsistencies, inconsistencies. SHOW SEMANTIC VIEWS does support paging, but it does not include
-			// semantic views; at least, it does not say so in the docs.
-			// So I guess we could use SHOW VIEWS to identify >10K materialized views, we'd have to filter out the
-			// SN_bla_bla Snowpark objects. We'd then have to separately query SEMANTIC VIEWS still, if we wanted to
-			// support those, too. If we query SHOW VIEWS, then it makes sense not to query them with SHOW OBJECTS at
-			// all, actually.
-			// And once we get there, it may make more sense to use SHOW TABLES, where we get a bit more flags as well.
-			
-			// WIP: fire query for materialized views, and delete matching records from toDetermine
-			// WIP: if toDetermine still has views, fire query for semantic views, and delete matching records from toDetermine
-			// WIP: yield any remaining views in toDetermine as regular views
-		}
-	}
-}
-
-func queryViews(ctx context.Context, conn *sql.DB, db semantics.Ident, schema semantics.Ident) iter.Seq2[viewRec,
-	error] {
-	// The main problem with the SHOW VIEWS function is that there is no flag "is_normal" for regular views.
-	// If new types of views are returned in the future, with flags like "is_new_type_X", "is_new_type_Y",
-	// grupr will treat it like a regular view.
-	// Until Snowflake adds a flag "is_normal" to the output of the SHOW VIEWS function (and friends like SHOW OBJECTS,
-	// SHOW TABLES, etc, I see no easy way to prevent this problem, other than quickly fixing grupr each time Snowflake
-	// comes out with something new (again).
-}
-
-func queryObjs(ctx context.Context, conn *sql.DB, db semantics.Ident, schema semantics.Ident) iter.Seq2[objRec, error] {
-	// The problem with the SHOW OBJECTS function is that there is no flag "is_regular" for regular tables.
-	// If new types of tables are returned in the future, with flags like "is_new_type_X", "is_new_type_Y",
-	// calling code will treat it like a regular table.
-	return func(yield func(Obj, error) bool) {
-		// When there are more than 10K results, paginate.
-		// Because we apply filters, even if fewer results are returned, perhaps there are still more.
-		// For that reason, our last row has a count of the first query result
-		mayHaveMore := true
-		var fromClause string
-		limit := 10000
-		for mayHaveMore {
-			rows, err := conn.QueryContext(ctx, fmt.Sprintf(`SHOW OBJECTS IN SCHEMA IDENTIFIER($$%s.%s$$) LIMIT %d%s ->>
-SELECT
-    NULL AS n
-  , "name" AS name
-  , "kind" AS kind
-  , "is_hybrid" AS is_hybrid
-  , "is_dynamic" AS is_dynamic
-  , "is_iceberg" AS is_iceberg
-  , "is_interactive" AS is_interactive
-  , "owner" AS owner
-FROM $1
-WHERE kind = '%s'
-UNION ALL
-SELECT
-    COUNT(*)
-  , '' AS name
-  , '' AS kind
-  , FALSE AS is_hybrid
-  , FALSE AS is_dynamic
-  , FALSE AS is_iceberg
-  , FALSE AS is_interactive
-  , '' AS owner
-FROM $1
-`, db, schema, limit, fromClause, ObjTpTable))
-			if err != nil {
-				if strings.Contains(err.Error(), "390201") { // ErrObjectNotExistOrAuthorized; this way of testing error code is used in errors_test in the gosnowflake repo
-					err = ErrObjectNotExistOrAuthorized
-				}
-				yield(Obj{}, err)
-				return
 			}
-			defer rows.Close()
-			var lastName semantics.Ident
-			for rows.Next() {
-				var n *int
-				var rec objRec
-				if err = rows.Scan(&n, &rec.name, &rec.kind, &rec.is_hybrid, &rec.is_dynamic, &rec.is_iceberg,
-					&rec.is_interactive, &rec.owner); err != nil {
-					err = fmt.Errorf("QueryObjs: error scanning row: %w", err)
-					yield(Obj{}, err)
-					return
+		}
+		for rec := range queryViews(ctx, conn, db, schema) {
+			if ot := rec.getObjType(); ot != ObjTpOther {
+				if !yield(Obj{Name: rec.name, ObjectType: ot, Owner: rec.owner}, nil) {
+						return
 				}
-				if n != nil { // this is the last row holding the count
-					if *n < limit {
-						mayHaveMore = false
-					} else {
-						fromClause = fmt.Sprintf(" FROM '%s'", string(lastName))
-					}
-					continue
-				}
-				if !yield(rec, nil) {
-					return
-				}
-				lastName = name
-			}
-			if err = rows.Err(); err != nil {
-				err = fmt.Errorf("QueryObjs: error after looping over results: %w", err)
-				yield(Obj{}, err)
-				return
 			}
 		}
 	}

--- a/internal/snowflake/obj_type.go
+++ b/internal/snowflake/obj_type.go
@@ -7,8 +7,17 @@ const (
 	ObjTpAccount
 	ObjTpDatabase
 	ObjTpDatabaseRole
+	ObjTpDynamicTable
+	ObjTpEventTable
+	ObjTpExternalTable
+	ObjTpHybridTable
+	ObjTpIcebergTable
+	ObjTpInteractiveTable
+	ObjTpMaterializedView
+	ObjTpOnlineFeatureTable
 	ObjTpRole
 	ObjTpSchema
+	ObjTpSemanticView
 	ObjTpTable
 	ObjTpUser
 	ObjTpView
@@ -17,31 +26,80 @@ const (
 
 func ParseObjType(s string) ObjType {
 	return map[string]ObjType{
-		"ACCOUNT":       ObjTpAccount,
-		"DATABASE":      ObjTpDatabase,
-		"DATABASE_ROLE": ObjTpDatabaseRole, // NB: in grant output we typically find DATABASE_ROLE (with underscore)
-		"ROLE":          ObjTpRole,
-		"SCHEMA":        ObjTpSchema,
-		"TABLE":         ObjTpTable,
-		"USER":          ObjTpUser,
-		"VIEW":          ObjTpView,
-		"WAREHOUSE":     ObjTpWarehouse,
+		"ACCOUNT":              ObjTpAccount,
+		"DATABASE":             ObjTpDatabase,
+		"DATABASE ROLE":        ObjTpDatabaseRole,
+		"DYNAMIC TABLE":        ObjTpDynamicTable,
+		"EVENT TABLE":          ObjTpEventTable,
+		"EXTERNAL TABLE":       ObjTpExternalTable,
+		"HYBRID TABLE":         ObjTpHybridTable,
+		"ICEBERG TABLE":        ObjTpIcebergTable,
+		"INTERACTIVE TABLE":    ObjTpInteractiveTable,
+		"MATERIALIZED VIEW":    ObjTpMaterializedView,
+		"ONLINE FEATURE TABLE": ObjTpOnlineFeatureTable,
+		"ROLE":                 ObjTpRole,
+		"SCHEMA":               ObjTpSchema,
+		"SEMANTIC VIEW":        ObjTpSemanticView,
+		"TABLE":                ObjTpTable,
+		"USER":                 ObjTpUser,
+		"VIEW":                 ObjTpView,
+		"WAREHOUSE":            ObjTpWarehouse,
 	}[s]
 }
 
 func (ot ObjType) String() string {
 	return map[ObjType]string{
-		ObjTpOther:        "OTHER",
-		ObjTpAccount:      "ACCOUNT",
-		ObjTpDatabase:     "DATABASE",
-		ObjTpDatabaseRole: "DATABASE_ROLE",
-		ObjTpRole:         "ROLE",
-		ObjTpSchema:       "SCHEMA",
-		ObjTpTable:        "TABLE",
-		ObjTpUser:         "USER",
-		ObjTpView:         "VIEW",
-		ObjTpWarehouse:    "WAREHOUSE",
+		ObjTpOther:              "OTHER",
+		ObjTpAccount:            "ACCOUNT",
+		ObjTpDatabase:           "DATABASE",
+		ObjTpDatabaseRole:       "DATABASE ROLE",
+		ObjTpDynamicTable:       "DYNAMIC TABLE",
+		ObjTpEventTable:         "EVENT TABLE",
+		ObjTpExternalTable:      "EXTERNAL TABLE",
+		ObjTpHybridTable:        "HYBRID TABLE",
+		ObjTpIcebergTable:       "ICEBERG TABLE",
+		ObjTpInteractiveTable:   "INTERACTIVE TABLE",
+		ObjTpMaterializedView:   "MATERIALIZED VIEW",
+		ObjTpOnlineFeatureTable: "ONLINE FEATURE TABLE",
+		ObjTpRole:               "ROLE",
+		ObjTpSchema:             "SCHEMA",
+		ObjTpSemanticView:       "SEMANTIC VIEW",
+		ObjTpTable:              "TABLE",
+		ObjTpUser:               "USER",
+		ObjTpView:               "VIEW",
+		ObjTpWarehouse:          "WAREHOUSE",
 	}[ot]
+}
+
+func ParseObjTypeFromShowObjectsRecord(kind string, is_hybrid bool, is_dynamic bool, is_iceberg bool,
+	is_interactive bool) (ObjType, bool) {
+	switch kind {
+	case "TABLE":
+		// TODO: there appears to be something like a dynamic iceberg table, for example, not sure how it would be
+		// represented here, and what would be the set of privileges we can assign an object like that, it is not
+		// separate treated in the Snowflake documentation page on access control privileges as of April 2026
+		if is_hybrid && !is_dynamic && !is_iceberg && !is_interactive {
+			return ObjTpHybridTable, true
+		}
+		if !is_hybrid && is_dynamic && !is_iceberg && !is_interactive {
+			return ObjTpDynamicTable, true
+		}
+		if !is_hybrid && !is_dynamic && is_iceberg && !is_interactive {
+			return ObjTpIcebergTable, true
+		}
+		if !is_hybrid && !is_dynamic && !is_iceberg && is_interactive {
+			return ObjTpInteractiveTable, true
+		}
+	case "ONLINE_FEATURE_TABLE":
+		return ObjTpOnlineFeatureTable, true
+	case "EVENT_TABLE": // TODO: validate this is how it appears in the output
+		return ObjTpEventTable, true
+	case "EXTERNAL_TABLE": // TODO: validate this is how it appears in the output
+		return ObjTpExternalTable, true
+	case "VIEW":
+		return ObjTpView, false // we cannot fully determine object type
+	}
+	return ObjTpOther, false
 }
 
 func (ot ObjType) getIdxObjectLevel() int {

--- a/internal/snowflake/obj_type.go
+++ b/internal/snowflake/obj_type.go
@@ -25,6 +25,7 @@ const (
 )
 
 func ParseObjType(s string) ObjType {
+	// s is a statement-style object type string
 	return map[string]ObjType{
 		"ACCOUNT":              ObjTpAccount,
 		"DATABASE":             ObjTpDatabase,
@@ -71,35 +72,14 @@ func (ot ObjType) String() string {
 	}[ot]
 }
 
-func ParseObjTypeFromShowObjectsRecord(kind string, is_hybrid bool, is_dynamic bool, is_iceberg bool,
-	is_interactive bool) (ObjType, bool) {
-	switch kind {
-	case "TABLE":
-		// TODO: there appears to be something like a dynamic iceberg table, for example, not sure how it would be
-		// represented here, and what would be the set of privileges we can assign an object like that, it is not
-		// separate treated in the Snowflake documentation page on access control privileges as of April 2026
-		if is_hybrid && !is_dynamic && !is_iceberg && !is_interactive {
-			return ObjTpHybridTable, true
-		}
-		if !is_hybrid && is_dynamic && !is_iceberg && !is_interactive {
-			return ObjTpDynamicTable, true
-		}
-		if !is_hybrid && !is_dynamic && is_iceberg && !is_interactive {
-			return ObjTpIcebergTable, true
-		}
-		if !is_hybrid && !is_dynamic && !is_iceberg && is_interactive {
-			return ObjTpInteractiveTable, true
-		}
-	case "ONLINE_FEATURE_TABLE":
-		return ObjTpOnlineFeatureTable, true
-	case "EVENT_TABLE": // TODO: validate this is how it appears in the output
-		return ObjTpEventTable, true
-	case "EXTERNAL_TABLE": // TODO: validate this is how it appears in the output
-		return ObjTpExternalTable, true
-	case "VIEW":
-		return ObjTpView, false // we cannot fully determine object type
-	}
-	return ObjTpOther, false
+func (ot ObjType) RecordString() string {
+	return ot.String() // TODO: and replace spaces with underscores
+}
+
+func ParseObjTypeFromRecord(s string) ObjType {
+	// s is a record-style object type string as found in output of
+	// SHOW OBJECTS and SHOW GRANTS
+	return ParseObjType(s) // TODO: and first replace underscores with spaces
 }
 
 func (ot ObjType) getIdxObjectLevel() int {

--- a/internal/snowflake/obj_type.go
+++ b/internal/snowflake/obj_type.go
@@ -1,5 +1,9 @@
 package snowflake
 
+import (
+	"strings"
+)
+
 type ObjType int
 
 const (
@@ -73,13 +77,13 @@ func (ot ObjType) String() string {
 }
 
 func (ot ObjType) RecordString() string {
-	return ot.String() // TODO: and replace spaces with underscores
+	return strings.ReplaceAll(ot.String(), " ", "_")
 }
 
 func ParseObjTypeFromRecord(s string) ObjType {
 	// s is a record-style object type string as found in output of
 	// SHOW OBJECTS and SHOW GRANTS
-	return ParseObjType(s) // TODO: and first replace underscores with spaces
+	return ParseObjType(strings.ReplaceAll(s, "_", " "))
 }
 
 func (ot ObjType) getIdxObjectLevel() int {

--- a/internal/snowflake/obj_type.go
+++ b/internal/snowflake/obj_type.go
@@ -31,16 +31,16 @@ func ParseObjType(s string) ObjType {
 	// that cannot be distinguished from regular tables in SQL statements
 	// and the output of SHOW GRANTS statements.
 	return map[string]ObjType{
-		"ACCOUNT":              ObjTpAccount,
-		"DATABASE":             ObjTpDatabase,
-		"DATABASE ROLE":        ObjTpDatabaseRole,
-		"MATERIALIZED VIEW":    ObjTpMaterializedView,
-		"ROLE":                 ObjTpRole,
-		"SCHEMA":               ObjTpSchema,
-		"TABLE":                ObjTpTable,
-		"USER":                 ObjTpUser,
-		"VIEW":                 ObjTpView,
-		"WAREHOUSE":            ObjTpWarehouse,
+		"ACCOUNT":           ObjTpAccount,
+		"DATABASE":          ObjTpDatabase,
+		"DATABASE ROLE":     ObjTpDatabaseRole,
+		"MATERIALIZED VIEW": ObjTpMaterializedView,
+		"ROLE":              ObjTpRole,
+		"SCHEMA":            ObjTpSchema,
+		"TABLE":             ObjTpTable,
+		"USER":              ObjTpUser,
+		"VIEW":              ObjTpView,
+		"WAREHOUSE":         ObjTpWarehouse,
 	}[s]
 }
 
@@ -48,18 +48,18 @@ func (ot ObjType) String() string {
 	// String representation of object type ready to be used
 	// in SQL statements
 	return map[ObjType]string{
-		ObjTpOther:              "OTHER",
-		ObjTpAccount:            "ACCOUNT",
-		ObjTpDatabase:           "DATABASE",
-		ObjTpDatabaseRole:       "DATABASE ROLE",
-		ObjTpHybridTable:        "TABLE", // Hybrid tables are indistinguishable from regular table in many SQL statements
-		ObjTpMaterializedView:   "MATERIALIZED VIEW",
-		ObjTpRole:               "ROLE",
-		ObjTpSchema:             "SCHEMA",
-		ObjTpTable:              "TABLE",
-		ObjTpUser:               "USER",
-		ObjTpView:               "VIEW",
-		ObjTpWarehouse:          "WAREHOUSE",
+		ObjTpOther:            "OTHER",
+		ObjTpAccount:          "ACCOUNT",
+		ObjTpDatabase:         "DATABASE",
+		ObjTpDatabaseRole:     "DATABASE ROLE",
+		ObjTpHybridTable:      "TABLE", // Hybrid tables are indistinguishable from regular table in many SQL statements
+		ObjTpMaterializedView: "MATERIALIZED VIEW",
+		ObjTpRole:             "ROLE",
+		ObjTpSchema:           "SCHEMA",
+		ObjTpTable:            "TABLE",
+		ObjTpUser:             "USER",
+		ObjTpView:             "VIEW",
+		ObjTpWarehouse:        "WAREHOUSE",
 	}[ot]
 }
 

--- a/internal/snowflake/obj_type.go
+++ b/internal/snowflake/obj_type.go
@@ -11,17 +11,10 @@ const (
 	ObjTpAccount
 	ObjTpDatabase
 	ObjTpDatabaseRole
-	ObjTpDynamicTable
-	ObjTpEventTable
-	ObjTpExternalTable
 	ObjTpHybridTable
-	ObjTpIcebergTable
-	ObjTpInteractiveTable
 	ObjTpMaterializedView
-	ObjTpOnlineFeatureTable
 	ObjTpRole
 	ObjTpSchema
-	ObjTpSemanticView
 	ObjTpTable
 	ObjTpUser
 	ObjTpView
@@ -30,21 +23,20 @@ const (
 
 func ParseObjType(s string) ObjType {
 	// s is a statement-style object type string
+	// Note that even though hybrid tables are managed by grupr, they
+	// are just called TABLE in SQL statements, and they also
+	// appear as TABLE in the output of SHOW GRANTS commands.
+	//
+	// Afaik, currently hybrid tables are the only special table type
+	// that cannot be distinguished from regular tables in SQL statements
+	// and the output of SHOW GRANTS statements.
 	return map[string]ObjType{
 		"ACCOUNT":              ObjTpAccount,
 		"DATABASE":             ObjTpDatabase,
 		"DATABASE ROLE":        ObjTpDatabaseRole,
-		"DYNAMIC TABLE":        ObjTpDynamicTable,
-		"EVENT TABLE":          ObjTpEventTable,
-		"EXTERNAL TABLE":       ObjTpExternalTable,
-		"HYBRID TABLE":         ObjTpHybridTable,
-		"ICEBERG TABLE":        ObjTpIcebergTable,
-		"INTERACTIVE TABLE":    ObjTpInteractiveTable,
 		"MATERIALIZED VIEW":    ObjTpMaterializedView,
-		"ONLINE FEATURE TABLE": ObjTpOnlineFeatureTable,
 		"ROLE":                 ObjTpRole,
 		"SCHEMA":               ObjTpSchema,
-		"SEMANTIC VIEW":        ObjTpSemanticView,
 		"TABLE":                ObjTpTable,
 		"USER":                 ObjTpUser,
 		"VIEW":                 ObjTpView,
@@ -53,22 +45,17 @@ func ParseObjType(s string) ObjType {
 }
 
 func (ot ObjType) String() string {
+	// String representation of object type ready to be used
+	// in SQL statements
 	return map[ObjType]string{
 		ObjTpOther:              "OTHER",
 		ObjTpAccount:            "ACCOUNT",
 		ObjTpDatabase:           "DATABASE",
 		ObjTpDatabaseRole:       "DATABASE ROLE",
-		ObjTpDynamicTable:       "DYNAMIC TABLE",
-		ObjTpEventTable:         "EVENT TABLE",
-		ObjTpExternalTable:      "EXTERNAL TABLE",
-		ObjTpHybridTable:        "HYBRID TABLE",
-		ObjTpIcebergTable:       "ICEBERG TABLE",
-		ObjTpInteractiveTable:   "INTERACTIVE TABLE",
+		ObjTpHybridTable:        "TABLE", // Hybrid tables are indistinguishable from regular table in SQL statements
 		ObjTpMaterializedView:   "MATERIALIZED VIEW",
-		ObjTpOnlineFeatureTable: "ONLINE FEATURE TABLE",
 		ObjTpRole:               "ROLE",
 		ObjTpSchema:             "SCHEMA",
-		ObjTpSemanticView:       "SEMANTIC VIEW",
 		ObjTpTable:              "TABLE",
 		ObjTpUser:               "USER",
 		ObjTpView:               "VIEW",

--- a/internal/snowflake/obj_type.go
+++ b/internal/snowflake/obj_type.go
@@ -72,14 +72,3 @@ func ParseObjTypeFromRecord(s string) ObjType {
 	// SHOW OBJECTS and SHOW GRANTS
 	return ParseObjType(strings.ReplaceAll(s, "_", " "))
 }
-
-func (ot ObjType) getIdxObjectLevel() int {
-	switch ot {
-	case ObjTpTable:
-		return 0
-	case ObjTpView:
-		return 1
-	default:
-		panic("not an object living within a schema or not yet implemented")
-	}
-}

--- a/internal/snowflake/obj_type.go
+++ b/internal/snowflake/obj_type.go
@@ -24,7 +24,7 @@ const (
 func ParseObjType(s string) ObjType {
 	// s is a statement-style object type string
 	// Note that even though hybrid tables are managed by grupr, they
-	// are just called TABLE in SQL statements, and they also
+	// are just called TABLE in many SQL statements, and they also
 	// appear as TABLE in the output of SHOW GRANTS commands.
 	//
 	// Afaik, currently hybrid tables are the only special table type
@@ -52,7 +52,7 @@ func (ot ObjType) String() string {
 		ObjTpAccount:            "ACCOUNT",
 		ObjTpDatabase:           "DATABASE",
 		ObjTpDatabaseRole:       "DATABASE ROLE",
-		ObjTpHybridTable:        "TABLE", // Hybrid tables are indistinguishable from regular table in SQL statements
+		ObjTpHybridTable:        "TABLE", // Hybrid tables are indistinguishable from regular table in many SQL statements
 		ObjTpMaterializedView:   "MATERIALIZED VIEW",
 		ObjTpRole:               "ROLE",
 		ObjTpSchema:             "SCHEMA",

--- a/internal/snowflake/privilege.go
+++ b/internal/snowflake/privilege.go
@@ -4,37 +4,58 @@ type Privilege int
 
 const (
 	PrvOther Privilege = iota // zero type is PrvOther
+	PrvApplyBudget
 	PrvCreate
+	PrvDelete
+	PrvEvolveSchema
+	PrvInsert
 	PrvMonitor
 	PrvOperate
 	PrvOwnership
 	PrvReferences
 	PrvSelect
+	PrvSelectErrorTable
+	PrvTruncate
+	PrvUpdate
 	PrvUsage
 )
 
 func ParsePrivilege(p string) Privilege {
 	return map[string]Privilege{
-		"CREATE":     PrvCreate,
-		"MONITOR":    PrvMonitor,
-		"OPERATE":    PrvOperate,
-		"OWNERSHIP":  PrvOwnership,
-		"REFERENCES": PrvReferences,
-		"SELECT":     PrvSelect,
-		"USAGE":      PrvUsage,
+		"APPLY BUDGET":       PrvApplyBudget,
+		"CREATE":             PrvCreate,
+		"DELETE":             PrvDelete,
+		"EVOLVE SCHEMA":      PrvEvolveSchema,
+		"INSERT":             PrvInsert,
+		"MONITOR":            PrvMonitor,
+		"OPERATE":            PrvOperate,
+		"OWNERSHIP":          PrvOwnership,
+		"REFERENCES":         PrvReferences,
+		"SELECT":             PrvSelect,
+		"SELECT ERROR TABLE": PrvSelect,
+		"TRUNCATE":           PrvTruncate,
+		"UPDATE":             PrvUpdate,
+		"USAGE":              PrvUsage,
 	}[p]
 }
 
 func (p Privilege) String() string {
 	return map[Privilege]string{
-		PrvOther:      "OTHER",
-		PrvCreate:     "CREATE",
-		PrvMonitor:    "MONITOR",
-		PrvOperate:    "OPERATE",
-		PrvOwnership:  "OWNERSHIP",
-		PrvReferences: "REFERENCES",
-		PrvSelect:     "SELECT",
-		PrvUsage:      "USAGE",
+		PrvOther:            "OTHER",
+		PrvApplyBudget:      "APPLY BUDGET",
+		PrvCreate:           "CREATE",
+		PrvDelete:           "DELETE",
+		PrvEvolveSchema:     "EVOLVE SCHEMA",
+		PrvInsert:           "INSERT",
+		PrvMonitor:          "MONITOR",
+		PrvOperate:          "OPERATE",
+		PrvOwnership:        "OWNERSHIP",
+		PrvReferences:       "REFERENCES",
+		PrvSelect:           "SELECT",
+		PrvSelectErrorTable: "SELECT ERROR TABLE",
+		PrvTruncate:         "TRUNCATE",
+		PrvUpdate:           "UPDATE",
+		PrvUsage:            "USAGE",
 	}[p]
 }
 

--- a/internal/snowflake/privilege.go
+++ b/internal/snowflake/privilege.go
@@ -59,23 +59,26 @@ func (p Privilege) String() string {
 	}[p]
 }
 
-func setFlagPrivilegeWarehouse(flags [2]bool, setFlag Privilege) [2]bool {
-	// TODO: add MONITOR
+func setFlagPrivilegeWarehouse(flags [3]bool, setFlag Privilege) [3]bool {
 	switch setFlag {
 	case PrvUsage:
 		flags[0] = true
-	case PrvOperate:
+	case PrvMonitor:
 		flags[1] = true
+	case PrvOperate:
+		flags[2] = true
 	}
 	return flags
 }
 
-func hasFlagPrivilegeWarehouse(flags [2]bool, flag Privilege) bool {
+func hasFlagPrivilegeWarehouse(flags [3]bool, flag Privilege) bool {
 	switch flag {
 	case PrvUsage:
 		return flags[0]
-	case PrvOperate:
+	case PrvMonitor:
 		return flags[1]
+	case PrvOperate:
+		return flags[2]
 	}
 	return false
 }

--- a/internal/snowflake/privilege.go
+++ b/internal/snowflake/privilege.go
@@ -59,18 +59,8 @@ func (p Privilege) String() string {
 	}[p]
 }
 
-func (p Privilege) getIdxObjectLevel() int {
-	switch p {
-	case PrvSelect:
-		return 0
-	case PrvReferences:
-		return 1
-	default:
-		panic("not an object level privilege or not yet implemented")
-	}
-}
-
 func setFlagPrivilegeWarehouse(flags [2]bool, setFlag Privilege) [2]bool {
+	// TODO: add MONITOR
 	switch setFlag {
 	case PrvUsage:
 		flags[0] = true

--- a/internal/snowflake/privilege.go
+++ b/internal/snowflake/privilege.go
@@ -6,7 +6,6 @@ const (
 	PrvOther Privilege = iota // zero type is PrvOther
 	PrvApplyBudget
 	PrvCreate
-	PrvCreateDatabaseRole
 	PrvDelete
 	PrvEvolveSchema
 	PrvInsert
@@ -25,7 +24,6 @@ func ParsePrivilege(p string) Privilege {
 	return map[string]Privilege{
 		"APPLYBUDGET":          PrvApplyBudget,
 		"CREATE":               PrvCreate,
-		"CREATE DATABASE ROLE": PrvCreateDatabaseRole,
 		"DELETE":               PrvDelete,
 		"EVOLVE SCHEMA":        PrvEvolveSchema,
 		"INSERT":               PrvInsert,
@@ -46,7 +44,6 @@ func (p Privilege) String() string {
 		PrvOther:              "OTHER",
 		PrvApplyBudget:        "APPLYBUDGET",
 		PrvCreate:             "CREATE",
-		PrvCreateDatabaseRole: "CREATE DATABASE ROLE",
 		PrvDelete:             "DELETE",
 		PrvEvolveSchema:       "EVOLVE SCHEMA",
 		PrvInsert:             "INSERT",

--- a/internal/snowflake/privilege.go
+++ b/internal/snowflake/privilege.go
@@ -22,7 +22,7 @@ const (
 
 func ParsePrivilege(p string) Privilege {
 	return map[string]Privilege{
-		"APPLY BUDGET":       PrvApplyBudget,
+		"APPLYBUDGET":        PrvApplyBudget,
 		"CREATE":             PrvCreate,
 		"DELETE":             PrvDelete,
 		"EVOLVE SCHEMA":      PrvEvolveSchema,
@@ -42,7 +42,7 @@ func ParsePrivilege(p string) Privilege {
 func (p Privilege) String() string {
 	return map[Privilege]string{
 		PrvOther:            "OTHER",
-		PrvApplyBudget:      "APPLY BUDGET",
+		PrvApplyBudget:      "APPLYBUDGET",
 		PrvCreate:           "CREATE",
 		PrvDelete:           "DELETE",
 		PrvEvolveSchema:     "EVOLVE SCHEMA",

--- a/internal/snowflake/privilege.go
+++ b/internal/snowflake/privilege.go
@@ -6,6 +6,7 @@ const (
 	PrvOther Privilege = iota // zero type is PrvOther
 	PrvApplyBudget
 	PrvCreate
+	PrvCreateDatabaseRole
 	PrvDelete
 	PrvEvolveSchema
 	PrvInsert
@@ -22,40 +23,42 @@ const (
 
 func ParsePrivilege(p string) Privilege {
 	return map[string]Privilege{
-		"APPLYBUDGET":        PrvApplyBudget,
-		"CREATE":             PrvCreate,
-		"DELETE":             PrvDelete,
-		"EVOLVE SCHEMA":      PrvEvolveSchema,
-		"INSERT":             PrvInsert,
-		"MONITOR":            PrvMonitor,
-		"OPERATE":            PrvOperate,
-		"OWNERSHIP":          PrvOwnership,
-		"REFERENCES":         PrvReferences,
-		"SELECT":             PrvSelect,
-		"SELECT ERROR TABLE": PrvSelect,
-		"TRUNCATE":           PrvTruncate,
-		"UPDATE":             PrvUpdate,
-		"USAGE":              PrvUsage,
+		"APPLYBUDGET":          PrvApplyBudget,
+		"CREATE":               PrvCreate,
+		"CREATE DATABASE ROLE": PrvCreateDatabaseRole,
+		"DELETE":               PrvDelete,
+		"EVOLVE SCHEMA":        PrvEvolveSchema,
+		"INSERT":               PrvInsert,
+		"MONITOR":              PrvMonitor,
+		"OPERATE":              PrvOperate,
+		"OWNERSHIP":            PrvOwnership,
+		"REFERENCES":           PrvReferences,
+		"SELECT":               PrvSelect,
+		"SELECT ERROR TABLE":   PrvSelect,
+		"TRUNCATE":             PrvTruncate,
+		"UPDATE":               PrvUpdate,
+		"USAGE":                PrvUsage,
 	}[p]
 }
 
 func (p Privilege) String() string {
 	return map[Privilege]string{
-		PrvOther:            "OTHER",
-		PrvApplyBudget:      "APPLYBUDGET",
-		PrvCreate:           "CREATE",
-		PrvDelete:           "DELETE",
-		PrvEvolveSchema:     "EVOLVE SCHEMA",
-		PrvInsert:           "INSERT",
-		PrvMonitor:          "MONITOR",
-		PrvOperate:          "OPERATE",
-		PrvOwnership:        "OWNERSHIP",
-		PrvReferences:       "REFERENCES",
-		PrvSelect:           "SELECT",
-		PrvSelectErrorTable: "SELECT ERROR TABLE",
-		PrvTruncate:         "TRUNCATE",
-		PrvUpdate:           "UPDATE",
-		PrvUsage:            "USAGE",
+		PrvOther:              "OTHER",
+		PrvApplyBudget:        "APPLYBUDGET",
+		PrvCreate:             "CREATE",
+		PrvCreateDatabaseRole: "CREATE DATABASE ROLE",
+		PrvDelete:             "DELETE",
+		PrvEvolveSchema:       "EVOLVE SCHEMA",
+		PrvInsert:             "INSERT",
+		PrvMonitor:            "MONITOR",
+		PrvOperate:            "OPERATE",
+		PrvOwnership:          "OWNERSHIP",
+		PrvReferences:         "REFERENCES",
+		PrvSelect:             "SELECT",
+		PrvSelectErrorTable:   "SELECT ERROR TABLE",
+		PrvTruncate:           "TRUNCATE",
+		PrvUpdate:             "UPDATE",
+		PrvUsage:              "USAGE",
 	}[p]
 }
 

--- a/internal/snowflake/product_dtap.go
+++ b/internal/snowflake/product_dtap.go
@@ -118,7 +118,7 @@ func (pd *ProductDTAP) createProductRoles(ctx context.Context, semCnf *semantics
 	conn *sql.DB, productRoles map[ProductRole]struct{}) error {
 	// Read role
 	pd.ReadRole = newProductRole(semCnf, pd.ProductID, pd.DTAP, ModeRead)
-	if _, ok := productRoles[pd.ReadRole]; !ok {
+	if _, ok := productRoles[pd.ReadRole]; !ok && !pd.isZombie {
 		if err := pd.ReadRole.Create(ctx, cnf, conn); err != nil {
 			return err
 		}
@@ -126,7 +126,7 @@ func (pd *ProductDTAP) createProductRoles(ctx context.Context, semCnf *semantics
 
 	// Write role, identical logic, maybe refactor
 	pd.WriteRole = newProductRole(semCnf, pd.ProductID, pd.DTAP, ModeWrite)
-	if _, ok := productRoles[pd.WriteRole]; !ok {
+	if _, ok := productRoles[pd.WriteRole]; !ok && !pd.isZombie {
 		if err := pd.WriteRole.Create(ctx, cnf, conn); err != nil {
 			return err
 		}

--- a/internal/snowflake/product_dtap.go
+++ b/internal/snowflake/product_dtap.go
@@ -25,8 +25,8 @@ type ProductDTAP struct {
 	WriteRole             ProductRole
 	GrantReadRoleToUsers  map[semantics.Ident]bool    // initially set to false, then to true if GRANTS are found in Snowflake
 	GrantWriteRoleToUsers map[semantics.Ident]bool    // initially set to false, then to true if GRANTS are found in Snowflake
-	ReadWarehouses        map[semantics.Ident][2]bool // initially set to false, then to true if GRANTS (USAGE, OPERATE) are found in Snowflake
-	WriteWarehouses       map[semantics.Ident][2]bool // initially set to false, then to true if GRANTS (USAGE, OPERATE) are found in Snowflake
+	ReadWarehouses        map[semantics.Ident][3]bool // initially set to false, then to true if GRANTS (USAGE, MONITOR, OPERATE) are found in Snowflake
+	WriteWarehouses       map[semantics.Ident][3]bool // initially set to false, then to true if GRANTS (USAGE, MONITOR, OPERATE) are found in Snowflake
 
 	writeRoleGrantedToUserManagedRoles map[semantics.Ident]struct{}
 	userManagedOwnersOfObjects         map[semantics.Ident]struct{}
@@ -57,8 +57,8 @@ func NewProductDTAP(pdID semantics.ProductDTAPID, isProd bool, pSem semantics.Pr
 		Consumes:              map[syntax.InterfaceID]string{},
 		GrantReadRoleToUsers:  map[semantics.Ident]bool{},
 		GrantWriteRoleToUsers: map[semantics.Ident]bool{},
-		ReadWarehouses:        map[semantics.Ident][2]bool{},
-		WriteWarehouses:       map[semantics.Ident][2]bool{},
+		ReadWarehouses:        map[semantics.Ident][3]bool{},
+		WriteWarehouses:       map[semantics.Ident][3]bool{},
 		matchedAccountObjects: map[semantics.ObjExpr]*matchedAccountObjs{},
 	}
 

--- a/internal/snowflake/product_dtap__objects.go
+++ b/internal/snowflake/product_dtap__objects.go
@@ -79,6 +79,10 @@ func (pd *ProductDTAP) setFutureGrantsToWriteRole(ctx context.Context, cnf *Conf
 		// grants itself. Instead, the idea is that sysadmins would arrange for any service account that
 		// deploys objects in this product dtap to assume the product role; when doing so, ownership is
 		// already automatic.
+
+		// WIP: correct future grants on tables like truncate, insert, update, delete, etc; these would
+		// be made redundant by ownership. In fact, that does mean we do manage these grants, in a way,
+		// and yes, we would revoke them if we found them.
 	}, nil) {
 		if err != nil {
 			return err
@@ -130,6 +134,30 @@ func (pd *ProductDTAP) setGrantsToWriteRole(ctx context.Context, cnf *Config, co
 			PrivilegeComplete: PrivilegeComplete{Privilege: PrvOwnership},
 			GrantedOn:         ObjTpView,
 		}: {},
+		GrantTemplate{
+			PrivilegeComplete: PrivilegeComplete{Privilege: PrvInsert},
+			GrantedOn:         ObjTpTable,
+		}: {},
+		GrantTemplate{
+			PrivilegeComplete: PrivilegeComplete{Privilege: PrvUpdate},
+			GrantedOn:         ObjTpTable,
+		}: {},
+		GrantTemplate{
+			PrivilegeComplete: PrivilegeComplete{Privilege: PrvTruncate},
+			GrantedOn:         ObjTpTable,
+		}: {},
+		GrantTemplate{
+			PrivilegeComplete: PrivilegeComplete{Privilege: PrvDelete},
+			GrantedOn:         ObjTpTable,
+		}: {},
+		GrantTemplate{
+			PrivilegeComplete: PrivilegeComplete{Privilege: PrvEvolveSchema},
+			GrantedOn:         ObjTpTable,
+		}: {},
+		GrantTemplate{
+			PrivilegeComplete: PrivilegeComplete{Privilege: PrvApplyBudget},
+			GrantedOn:         ObjTpTable,
+		}: {},
 	}, nil) {
 		if err != nil {
 			return err
@@ -169,6 +197,13 @@ func (pd *ProductDTAP) setGrantsToWriteRole(ctx context.Context, cnf *Config, co
 			}
 			// Ignore, unmanaged grant
 		}
+		case PrvInsert, PrvUpdate, PrvTruncate, PrvDelete, PrvEvolveSchema, PrvApplyBudget:
+			switch g.GrantedOn {
+			case ObjTpTable:
+				// We revoke this grant, as it will be redundant given the ownership privilege
+				pd.toRevokeObjects = append(pd.toRevokeObjects, g)
+			}
+			// Ignore
 		// Ignore; unmanaged grant
 	}
 	return nil

--- a/internal/snowflake/product_dtap__objects.go
+++ b/internal/snowflake/product_dtap__objects.go
@@ -161,14 +161,20 @@ func (pd *ProductDTAP) setGrantsToWriteRole(ctx context.Context, cnf *Config, co
 					// so that would be a piece of code that would have to try different kinds of strategies
 					// until it finds something. e.g., try DESCRIBE TABLE, then try DESCRIBE DYNAMIC TABLE, etc.
 					// Or do a SHOW OBJECTS, covering regular, hybrid, dynamic, and iceberg tables, and then
-					// if you still don't find it, do external tables, event tables, interactive tables, etc.
+					// if you still don't find it, do external tables, event tables, interactive tables, online feature
+					// tables, directory tables, etc. Actually, many of those would probably occur in the output
+					// of SHOW OBJECTS; only, it would not be possible to tell them apart from regular, normal tables.
+					// Unfortunately, the output does not contain a column "is_normal".
 					// Perhaps in our account cache we should actually keep all kinds of tables there are,
 					// so that we do have all the info, even if we are not managing grants on such types of
 					// objects yet.
 					// If we did that, it would be nice to have ObjType values for each kind, the only trouble
 					// is that when we query for grants in Snowflake, Snowflake will always just say TABLE,
-					// so when we deserialize a row like that, it would contain erroneous data. We could also
-					// use ObjTpTable for all of them, and then have properties like is_external, etc.
+					// so when we deserialize a row like that, it would contain erroneous data. But, we'll just
+					// have to take that into account, then. Actually, it's worse, for like a hybrid table
+					// the granted_on column would just show TABLE, but, for example, for an interactive table,
+					// there is an example in the docs where it shows as "INTERACTIVE_TABLE". Unfortunately,
+					// the documentation does not provide an exhaustive list of possible values.
 					//
 					// And what about secure views, materialized views, and semantic views?
 					//
@@ -176,8 +182,97 @@ func (pd *ProductDTAP) setGrantsToWriteRole(ctx context.Context, cnf *Config, co
 					// some inconsistencies, probably due to the speed with which new features are added and
 					// launched. That makes it harder for a tool like grupr to achieve consistent access management
 					// in a simple manner.
+					// Because the SHOW GRANTS APIs treat everything as a table, when I am now transfering ownership
+					// away, I am already managing grants on object types I do not manage. Managing all object types
+					// would make the code only simpler, actually, if a lot longer.
 
-					// And what about interactive warehouses :-)
+					// TDOD what about interactive warehouses :-) I suppose grupr should add all interactive tables
+					// to all interactive warehouses that have been granted to either the product roles or product
+					// roles of consumers. And of course remove the tables if usage grants on those warehouses change
+
+					// Okay, so these Snowflake APIs are a bit of a mess actually, too bad. It's not even possible to
+					// query only "normal" tables and "normal" views. We can try something here:
+					// what if we say that, you know, if you have a grant here on an object that you don't match,
+					// in the YAML, that's already enough to revoke it, no matter what it is. And yes, even if
+					// that's ownership, you revoke it, which you do by transferring it, in this case. So, in this
+					// case, yes, we chose to risk to break something: we just have to say: please don't grant anything
+					// on an object to a grupr managed role unless it's matched by the relevant object expressions.
+					// and if you change those expressions, or if you change the name of a product or interface, be
+					// aware that those grants will be revoked.
+					// Okay, and, if we have a grant here, and it is on an object matched by the YAML, but, we
+					// did not find it, then maybe it is because SHOW objects did not return this type of object,
+					// (the documentation is not clear on exactly what is and is not returned), and therefore,
+					// by accident, by this circumstance, grupr does not support this type of object yet, and
+					// therefore we will leave the grant be.
+					// Okay, so now, if we try to live with not knowing the object type, then we should think about
+					// what to grant. Read privileges first. SELECT will always be okay. REFERENCES is not supported for dynamic tables and
+					// online feature tables. MONITOR is only relevant for certain types of tables, we might omit
+					// it altogether, if you want to enable people to monitor, say, a dynamic table, you are out of luck
+					// and you have to do it yourself. Now in this case, we should not revoke this privilege if it was
+					// there.
+					// For write privileges, we do need to revoke everything: except ownership, which is valid for all
+					// types of objects.
+					// You know, even if it may be very painful to write all the queries necessary to figure out exactly
+					// the type of object for each and every object, it would make reasoning about correctness of the
+					// code a lot easier if we made a decent attempt at exactly that.
+
+					// ouch, you know, when it would come to implement the ability to manage grants on objects
+					// exclusively, we will have to query grants on objects. And to do that, we'd definitely need
+					// to know the type of each object.
+					// Oh, wow, just created a hybrid table, and then queried the grants on it with these queries:
+					// - show grants on table x.y.z --works;
+					// - show grants on hybrid table x.y.z --error;
+					// - show grants on dynamic table x.y.z --works;
+					// - show grants on iceberg table x.y.z --works;
+					// - show grants on interactive table x.y.z --works;
+					// - show grants on external table x.y.z --works;
+					// - show grants on online feature table x.y.z --works;
+					//
+					// Not only is it completely undocumented for this statement what the valid object types are,
+					// the statement also fails to check whether the object is actually of the specified type.
+					//
+					// But, I guess, as Snowflake matures, eventually, eventually, they will correct their APIs,
+					// and, we should aim to use the correct statements.
+					// Already, as of Apr 2026, the GRANT statement is much more explicit about the possible schema level 
+					// object types: https://docs.snowflake.com/en/sql-reference/sql/grant-privilege
+					//
+					// We would be supporting, initially:
+					//
+					// DYNAMIC TABLE
+					// EVENT TABLE
+					// EXTERNAL TABLE
+					// ICEBERG TABLE
+					// INTERACTIVE TABLE
+					// MATERIALIZED VIEW
+					// ONLINE FEATURE TABLE
+					// SEMANTIC VIEW
+					// TABLE
+					// VIEW
+					//
+					// All of these are just tables and views, really, and that's what people would expect to
+					// be able to manage with a tool like grupr.
+					// Even just to correctly issue GRANT and REVOKE statements for these types of objects,
+					// many of which are already returned by SHOW OBJECTS (probably ;-)), we need to know
+					// the exact object type
+					// And we need to find out as well how these object types are represented in the output
+					// of SHOW GRANTS commands, I've seen myself that HYBRID TABLE is just represented as TABLE,
+					// while an INTERACTIVE TABLE is represented as INTERACTIVE_TABLE. HYBRID TABLE is also
+					// not a valid object_type in the GRANT TO ROLE statement. DYNAMIC TABLE is. Can we expect
+					// that the latter would appear as DYNAMIC_TABLE?
+					// So to validate this, we'd have no other way than to just create at least one example
+					// of each kind of table and view, hopefully the set-up costs won't be too high for any of
+					// them, but it will certainly take some time to figure out how, at this moment, in all
+					// the various "official" and partially documented APIs and output each of them is
+					// represented, if at all.
+					//
+					// We could also try to limit ourselves first and say we only manage normal tables, but
+					// even then we need to establish how to query only normal tables; sadly SHOW OBJECTS does
+					// not have a column "is_normal", and neither does "SHOW TABLES". Querying the information
+					// schema there is something called "BASE TABLE", but it might be referring to a slightly
+					// different distinction, and it is an entirely different API than what we have been using
+					// so far. The Snowflake REST API also mentions a table type "NORMAL", but, that API comes
+					// with its own quirks as well. Anyway, I gave some feedback on the Snowflake docs,
+					// and, am calling it a day.
 				}
 			}
 			// Ignore, unmanaged grant

--- a/internal/snowflake/product_dtap__objects.go
+++ b/internal/snowflake/product_dtap__objects.go
@@ -117,48 +117,7 @@ func (pd *ProductDTAP) setGrantsToWriteRole(ctx context.Context, cnf *Config, co
 	if _, ok := productRoles[pd.WriteRole]; !ok && cnf.DryRun {
 		return nil
 	}
-	for g, err := range QueryGrantsToRoleFiltered(ctx, cnf, conn, pd.WriteRole.ID, map[GrantTemplate]struct{}{
-		GrantTemplate{
-			PrivilegeComplete: PrivilegeComplete{Privilege: PrvCreate, CreateObjectType: ObjTpTable},
-			GrantedOn:         ObjTpSchema,
-		}: {},
-		GrantTemplate{
-			PrivilegeComplete: PrivilegeComplete{Privilege: PrvCreate, CreateObjectType: ObjTpView},
-			GrantedOn:         ObjTpSchema,
-		}: {},
-		GrantTemplate{
-			PrivilegeComplete: PrivilegeComplete{Privilege: PrvOwnership},
-			GrantedOn:         ObjTpTable,
-		}: {},
-		GrantTemplate{
-			PrivilegeComplete: PrivilegeComplete{Privilege: PrvOwnership},
-			GrantedOn:         ObjTpView,
-		}: {},
-		GrantTemplate{
-			PrivilegeComplete: PrivilegeComplete{Privilege: PrvInsert},
-			GrantedOn:         ObjTpTable,
-		}: {},
-		GrantTemplate{
-			PrivilegeComplete: PrivilegeComplete{Privilege: PrvUpdate},
-			GrantedOn:         ObjTpTable,
-		}: {},
-		GrantTemplate{
-			PrivilegeComplete: PrivilegeComplete{Privilege: PrvTruncate},
-			GrantedOn:         ObjTpTable,
-		}: {},
-		GrantTemplate{
-			PrivilegeComplete: PrivilegeComplete{Privilege: PrvDelete},
-			GrantedOn:         ObjTpTable,
-		}: {},
-		GrantTemplate{
-			PrivilegeComplete: PrivilegeComplete{Privilege: PrvEvolveSchema},
-			GrantedOn:         ObjTpTable,
-		}: {},
-		GrantTemplate{
-			PrivilegeComplete: PrivilegeComplete{Privilege: PrvApplyBudget},
-			GrantedOn:         ObjTpTable,
-		}: {},
-	}, nil) {
+	for g, err := range QueryGrantsToRoleFiltered(ctx, cnf, conn, pd.WriteRole.ID, cnf.ObjectPrivileges, nil) {
 		if err != nil {
 			return err
 		}
@@ -193,15 +152,54 @@ func (pd *ProductDTAP) setGrantsToWriteRole(ctx context.Context, cnf *Config, co
 					// transfer its ownership to a role that is not managed by grupr.
 					// Note that when we refreshed, toTransferOwnership was reset to an empty slice
 					pd.toTransferOwnership = append(pd.toTransferOwnership, g)
+					// WIP: We don't want to transfer ownership on unmanaged objects like dynamic tables!?
+					// even if they are disjoint from the grupin?! cause it would be like altering an
+					// unmanaged grant. How to distinguish in this case between regular tables disjoint
+					// from the grupin, and, say, external, event, hybrid, etc tables? Perhaps there will
+					// be no other way than to do another, ad hoc, query, to find out.
+					// Even that is not simple, however, because the way to query it depends on what it is,
+					// so that would be a piece of code that would have to try different kinds of strategies
+					// until it finds something. e.g., try DESCRIBE TABLE, then try DESCRIBE DYNAMIC TABLE, etc.
+					// Or do a SHOW OBJECTS, covering regular, hybrid, dynamic, and iceberg tables, and then
+					// if you still don't find it, do external tables, event tables, interactive tables, etc.
+					// Perhaps in our account cache we should actually keep all kinds of tables there are,
+					// so that we do have all the info, even if we are not managing grants on such types of
+					// objects yet.
+					// If we did that, it would be nice to have ObjType values for each kind, the only trouble
+					// is that when we query for grants in Snowflake, Snowflake will always just say TABLE,
+					// so when we deserialize a row like that, it would contain erroneous data. We could also
+					// use ObjTpTable for all of them, and then have properties like is_external, etc.
+					//
+					// And what about secure views, materialized views, and semantic views?
+					//
+					// You know, the Snowflake APIs for creating objects and querying grants on them have
+					// some inconsistencies, probably due to the speed with which new features are added and
+					// launched. That makes it harder for a tool like grupr to achieve consistent access management
+					// in a simple manner.
+
+					// And what about interactive warehouses :-)
 				}
 			}
 			// Ignore, unmanaged grant
 		}
-		case PrvInsert, PrvUpdate, PrvTruncate, PrvDelete, PrvEvolveSchema, PrvApplyBudget:
+		case PrvInsert, PrvUpdate, PrvTruncate, PrvDelete, PrvEvolveSchema, PrvApplyBudget,
+        	PrvSelect, PrvSelectErrorTable, PrvReferences:
 			switch g.GrantedOn {
-			case ObjTpTable:
-				// We revoke this grant, as it will be redundant given the ownership privilege
-				pd.toRevokeObjects = append(pd.toRevokeObjects, g)
+			case ObjTpTable, ObjTpView:
+				// We revoke this grant, as it is redundant in grupr it's access management model. But, we need to check
+				// if we found the object in question, before we revoke: this could be a dynamic, event, external,
+				// hybrid, or iceberg table, which we do not manage yet; we leave unmanaged grants intact not to break
+				// anything.
+				// 
+				// If this is a regular table or view, and we did not find it, it means the object was created after we
+				// refreshed objects, and then some of these privileges were granted.  So if we do not have the table in
+				// our accountobjects in memory, we have no way of knowing for sure whether or not this is a type of
+				// table we don't support yet (dynamic, iceberg, hybrid, event, external, ...) Therefore, we will not
+				// revoke in that case also. If it was a regular table, the next time grupr runs, the object will be
+				// found, and the privilege revoked.
+				if _, ok := pd.Interface.aggAccountObjects.GetObject(g.Database, g.Schema, g.Object); ok {
+					pd.toRevokeObjects = append(pd.toRevokeObjects, g)
+				}
 			}
 			// Ignore
 		// Ignore; unmanaged grant

--- a/internal/snowflake/product_dtap__objects.go
+++ b/internal/snowflake/product_dtap__objects.go
@@ -273,6 +273,18 @@ func (pd *ProductDTAP) setGrantsToWriteRole(ctx context.Context, cnf *Config, co
 					// so far. The Snowflake REST API also mentions a table type "NORMAL", but, that API comes
 					// with its own quirks as well. Anyway, I gave some feedback on the Snowflake docs,
 					// and, am calling it a day.
+
+					// SOLUTION, WIP:
+					// We will process candidate objects for transferring ownership as follows:
+					// - for all schema's in the collection of to transfer objects, create a matching expression,
+					// - use the matching expressions to query the account cache
+					// - if the objects are subsequently found in the account cache, they are of a type that
+					//   is in scope for grupr normally, and ownership can be transferred.
+					// - if the objects are subsequently not found in the account cache, they are of a type
+					//   for which grupr is not (yet) managing privileges, in this case, sysadmins must have
+					//   granted the privilege using other means, and grupr will not revoke it and not
+					//   transfer ownership.
+					// We will treat revoke candidates the same way.
 				}
 			}
 			// Ignore, unmanaged grant

--- a/internal/snowflake/product_dtap__objects.go
+++ b/internal/snowflake/product_dtap__objects.go
@@ -66,7 +66,7 @@ func (pd *ProductDTAP) setGrantActionsFutureObjectsWriteRole(ctx context.Context
 	if _, ok := productRoles[pd.WriteRole]; !ok && cnf.DryRun {
 		return nil
 	}
-	for g, err := range QueryFutureGrantsToRoleFiltered(ctx, conn, pd.WriteRole.ID,	cnf.ObjectPrivileges, nil) {
+	for g, err := range QueryFutureGrantsToRoleFiltered(ctx, conn, pd.WriteRole.ID,	cnf.ObjectPrivilegesOwnership, nil) {
 		if err != nil {
 			return err
 		}
@@ -86,9 +86,70 @@ func (pd *ProductDTAP) setGrantActionsFutureObjectsWriteRole(ctx context.Context
 						// 1. The schema was created after we matched objects, but before we queried future grants on
 						// the write role.
 						// 2. Despite the fact that the grant_on column matches our grant template, the object is not of
-						// a kind that grupr is managing after all. At the moment, that should not occur, but it may
-						// occur in the future as Snowflake is changing continuously. 
-						// In both cases, it would be okay to leave the grant intact.
+						// a kind that grupr is managing after all. 
+						//
+						// Case 2 is more likely to occur. This is at the moment the case with tables in 
+						// imported databases (like SNOWFLAKE_SAMPLE_DATA) and views in applications, as in
+						// SNOWFLAKE.ACCOUNT_USAGE.ACCESS_HISTORY). When scanning for objects, we currently only
+						// consider standard databases.
+						// So when users grant privileges on objects in such databases to the product role,
+						// but they are not matched by the YAML, then, currently, we drop them.
+						// If you want grupr to retain such grants, you should include them in the YAML.
+						// But if you want multiple product roles to have, say, select privileges on such an object,
+						// you would have to add the same object to the YAML of two different products, and you can't
+						// do that in grupr. So, this is an example where you would really get stuck if you used grupr.
+						// Unless, prior to revoking, we try once more if we can find the object; and then if not,
+						// then we conclude it was not a managed object, and therefore the grant is not managed.
+						//
+						// Consumer accounts lack privileges to grant privileges on individual objects in imported
+						// databases to roles. They can only grant usage on database roles in the exported database that
+						// exists in the producer account. Or they can grant IMPORTED PRIVILEGES and then the whole
+						// share is accessible to the grantee. Grants on individual objects in the imported database
+						// nevertheless show up in the output of SHOW GRANTS.
+						//
+						// The Snowflake datbase shows up as 'APPLICATION' in the output of SHOW DATABASES, but 
+						// is also an imported database and privilges on it can be granted to other roles in the same way.
+						// Grants on objects do show up in the output of SHOW GRANTS. A lot of them, especially if
+						// sysadmins granted IMPORTED PRIVILEGES.
+						//
+						// As of now grupr cannot grant privileges on objects in imported databases. To do so would
+						// require Snowflake specific YAML in which imported databases and their database roles are
+						// mentioned and can be granted to product (roles) explicitly. Until we get there, however,
+						// we need a way for grupr to ignore such grants. I see two ways, broadly:
+						//
+						// 1. Query explicitly for databases of types APPLICATION and IMPORTED DATABASE, and whenever
+						// we are processing the output of SHOW GRANTS, and the Databsase field of a grant equals 
+						// an imported database, ignore it, and skip to the next one (or even alter the SHOW GRANTS
+						// query to filter out such records server-side).
+						//
+						// 2. Like we do now, ignore everything but STANDARD databases when we query for databases.
+						// When people put YAML that matches such objects, no matching objects will be found.
+						// When we process the output of SHOW GRANTS, objects from other types of databases will
+						// either be ignored (if they are matched by the YAML), or, if they are not matched (more
+						// likely, reflecting correct YAML), then they will be a revoke candidate. However, prior
+						// to revoking, it will be checked if the object can be found using the same machinery
+						// (account cache) as was used to match objects in the YAML. Then, if the object can not
+						// be found, it will be regarded as an object that grupr apparently does not yet manage.
+						//
+						// The pro of method 2 is that it does not require us to model stuff we do not yet support.
+						// Snowflake can at any moment introduce yet new types of databases, schemas, and objects.
+						// Having a way to just use the way we normally get information on objects also when processing
+						// the output of SHOW GRANTS will give some piece of mind that grupr will less frequently 
+						// and less urgently need updatting.
+						// But it does come with a performance hit. We will be processing all this output from
+						// show grants. And some additional SHOW TABLES / VIEWS commands will be fired.
+						// Also, if we go with method 2, it will mean that there can be unmanaged grants hiding
+						// even in the results for our query for managed grants only.
+						// Fortunately, when it comes to our database roles, they will not have any such grants.
+						// So in that respect, no great code change is needed.
+						// Okay, so, we go with method 2, then.
+						//
+						// But, hey, no role would get CREATE on an imported database.
+						// And, SELECT rights, we exclusively manage them via DATABASE roles.
+						// So, we have no problem! We would ignore SELECT grants anyway, when they are
+						// granted to product roles, be they read roles or write roles.
+						// Any privileges that we do manage on behalf of product roles would never be granted
+						// directly on either imported or application databases--at least at the moment (May 2026).
 						continue
 					}
 				case PrvUsage, PrvMonitor:
@@ -100,6 +161,7 @@ func (pd *ProductDTAP) setGrantActionsFutureObjectsWriteRole(ctx context.Context
 			}
 		}
 		// If we are still here, this grant will be a revoke candidate.
+		// Note that we revoke ownership on future objects of types we manage this way, should sysadmins have granted that
 		pd.toRevokeFutureObjects = append(pd.toRevokeFutureObjects, g)
 	}
 	return nil
@@ -335,12 +397,13 @@ func (pd *ProductDTAP) getTodoGrantsFutureObjectsWriteRole() iter.Seq[FutureGran
 		for db, dbObjs := range pd.Interface.aggAccountObjects.DBs {
 			if dbObjs.MatchAllSchemas {
 				prvs := []PrivilegeComplete{}
-				for _, p := range [2]PrivilegeComplete{
+				for _, pc := range [2]PrivilegeComplete{
 					PrivilegeComplete{Privilege: PrvCreate, CreateObjectType: ObjTpTable},
 					PrivilegeComplete{Privilege: PrvCreate, CreateObjectType: ObjTpView},
+					PrivilegeComplete{Privilege: PrvCreate, CreateObjectType: ObjTpMaterializedView},
 				} {
-					if !dbObjs.hasFutureGrantTo(ModeWrite, ObjTpSchema, p) {
-						prvs = append(prvs, p)
+					if !dbObjs.hasFutureGrantTo(ModeWrite, ObjTpSchema, pc) {
+						prvs = append(prvs, pc)
 					}
 				}
 				if len(prvs) > 0 {
@@ -365,12 +428,13 @@ func (pd *ProductDTAP) getToDoGrantsObjectsWriteRole() iter.Seq[Grant] {
 		for db, dbObjs := range pd.Interface.aggAccountObjects.DBs {
 			for schema, schemaObjs := range dbObjs.Schemas {
 				prvs := []PrivilegeComplete{}
-				for _, p := range [2]PrivilegeComplete{
+				for _, pc := range [2]PrivilegeComplete{
 					PrivilegeComplete{Privilege: PrvCreate, CreateObjectType: ObjTpTable},
 					PrivilegeComplete{Privilege: PrvCreate, CreateObjectType: ObjTpView},
+					PrivilegeComplete{Privilege: PrvCreate, CreateObjectType: ObjTpMaterializedView},
 				} {
-					if !schemaObjs.hasGrantTo(ModeWrite, p) {
-						prvs = append(prvs, p)
+					if !schemaObjs.hasGrantTo(ModeWrite, pc) {
+						prvs = append(prvs, pc)
 					}
 				}
 				if len(prvs) > 0 {

--- a/internal/snowflake/product_dtap__objects.go
+++ b/internal/snowflake/product_dtap__objects.go
@@ -64,26 +64,7 @@ func (pd *ProductDTAP) setFutureGrantsToWriteRole(ctx context.Context, cnf *Conf
 	if _, ok := productRoles[pd.WriteRole]; !ok && cnf.DryRun {
 		return nil
 	}
-	for g, err := range QueryFutureGrantsToRoleFiltered(ctx, conn, pd.WriteRole.ID, map[GrantTemplate]struct{}{
-		GrantTemplate{
-			PrivilegeComplete: PrivilegeComplete{Privilege: PrvCreate, CreateObjectType: ObjTpTable},
-			GrantedOn:         ObjTpSchema,
-		}: {},
-		GrantTemplate{
-			PrivilegeComplete: PrivilegeComplete{Privilege: PrvCreate, CreateObjectType: ObjTpView},
-			GrantedOn:         ObjTpSchema,
-		}: {},
-		// Ignoring other grants, including future ownership grants. It would be quite annoying if such grants
-		// were present, they would interfere with grupr (basically grupr would correct them if they grant
-		// ownership to any other role than the product dtap role). But, grupr does not use future ownership
-		// grants itself. Instead, the idea is that sysadmins would arrange for any service account that
-		// deploys objects in this product dtap to assume the product role; when doing so, ownership is
-		// already automatic.
-
-		// WIP: correct future grants on tables like truncate, insert, update, delete, etc; these would
-		// be made redundant by ownership. In fact, that does mean we do manage these grants, in a way,
-		// and yes, we would revoke them if we found them.
-	}, nil) {
+	for g, err := range QueryFutureGrantsToRoleFiltered(ctx, conn, pd.WriteRole.ID,	cnf.ObjectPrivileges, nil) {
 		if err != nil {
 			return err
 		}
@@ -92,22 +73,29 @@ func (pd *ProductDTAP) setFutureGrantsToWriteRole(ctx context.Context, cnf *Conf
 		case ObjTpDatabase:
 			switch g.GrantedOn {
 			case ObjTpSchema:
-				// Should we have this grant?
-				if pd.Interface.ObjectMatchers.MatchAllSchemasInDB(g.Database) {
-					// If yes, then, if we also have matched the object, mark on it that privilege on future objects was already granted
-					if dbObjs, ok := pd.Interface.aggAccountObjects.DBs[g.Database]; ok {
-						dbObjs.setFutureGrantTo(ModeWrite, g)
+				switch g.Privileges[0].Privilege {
+				case PrvCreate:
+					// Should we have this grant?
+					if pd.Interface.ObjectMatchers.MatchAllSchemasInDB(g.Database) {
+						// If yes, then, if we also have matched the object, mark on it that privilege on future objects was already granted
+						if dbObjs, ok := pd.Interface.aggAccountObjects.DBs[g.Database]; ok {
+							dbObjs.setFutureGrantTo(ModeWrite, g)
+						}
+					} else {
+						// if not, then revoke this future grant
+						//
+						// Note that when we refreshed, we reset toRevokeFutureObjects to the empty slice
+						pd.toRevokeFutureObjects = append(pd.toRevokeFutureObjects, g)
 					}
-				} else {
-					// if not, then revoke this future grant
-					//
-					// Note that when we refreshed, we reset toRevokeFutureObjects to the empty slice
+				default:
 					pd.toRevokeFutureObjects = append(pd.toRevokeFutureObjects, g)
 				}
+			default:
+				pd.toRevokeFutureObjects = append(pd.toRevokeFutureObjects, g)
 			}
-			// Ignore this grant, it's not in grupr its scope (unmanaged grant)
+		default:
+			pd.toRevokeFutureObjects = append(pd.toRevokeFutureObjects, g)
 		}
-		// Ignore; unmanaged grant
 	}
 	return nil
 }

--- a/internal/snowflake/product_dtap__objects.go
+++ b/internal/snowflake/product_dtap__objects.go
@@ -200,71 +200,6 @@ func (pd *ProductDTAP) setUserManagedOwnersOfObjects(semCnf *semantics.Config, c
 	return nil
 }
 
-func (pd *ProductDTAP) setGrantActionsFutureObjectsReadRole(ctx context.Context, cnf *Config, conn *sql.DB, productRoles map[ProductRole]struct{}) error {
-	// This function covers setting the todo and already done actions regarding privileges on future objects for the
-	// product read role. Objects are refreshed when a product is refreshed.
-	// It does not cover compute privileges, and it does not cover usage of database roles.
-	if _, ok := productRoles[pd.ReadRole]; !ok && cnf.DryRun {
-		return nil
-	}
-	for g, err := range QueryFutureGrantsToRoleFiltered(ctx, conn, pd.ReadRole.ID,	cnf.ObjectPrivileges, nil) {
-		if err != nil {
-			return err
-		}
-		switch g.GrantedIn {
-		case ObjTpDatabase:
-			switch g.GrantedOn {
-			case ObjTpSchema:
-				switch g.Privileges[0].Privilege {
-				case PrvUsage, PrvMonitor:
-					// Grupr does not normally assign these privileges, but sysadmins are encouraged to do so in case
-					// they want to grant privileges on objects in schemas directly to the read role that grupr does not (yet)
-					// manage. For that reason, we will leave these grants intact.
-					// Note though, that for read privileges, it would be more natural for sysadmins to assign them to database roles.
-					continue
-				}
-			}
-		}
-		// If we are still here, this grant will be a revoke candidate.
-		pd.toRevokeFutureObjects = append(pd.toRevokeFutureObjects, g)
-	}
-	return nil
-}
-
-func (pd *ProductDTAP) setGrantActionsObjectsReadRole(ctx context.Context, cnf *Config, conn *sql.DB,
-	grupinDisjointFromObject func(semantics.Ident, semantics.Ident, semantics.Ident) bool, productRoles map[ProductRole]struct{}) error {
-	// This function covers setting the todo and already done actions regarding privileges on objects for the product
-	// read role. Objects are refreshed when products are refreshed.
-	// It does not cover compute privileges, and it does not cover usage of database roles.
-	if _, ok := productRoles[pd.ReadRole]; !ok && cnf.DryRun {
-		return nil
-	}
-	for g, err := range QueryGrantsToRoleFiltered(ctx, cnf, conn, pd.ReadRole.ID, cnf.ObjectPrivileges, nil) {
-		if err != nil {
-			return err
-		}
-		switch g.Privileges[0].Privilege {
-		case PrvOwnership:
-			if grupinDisjointFromObject(g.Database, g.Schema, g.Object) {
-				// There will be no other product claiming ownership of this object, we need to
-				// transfer its ownership to a role that is not managed by grupr.
-				// Note that when we refreshed, toTransferOwnership was reset to an empty slice
-				pd.toTransferOwnership = append(pd.toTransferOwnership, g)
-			}
-			continue // There is no revoking ownersip, so, continue either way
-		case PrvUsage, PrvMonitor:
-			// Grupr does not normally assign these privileges, but sysadmins are encouraged to do so in case
-			// they want to grant privileges on objects in schemas to the write role that grupr does not (yet)
-			// manage. For that reason, we will leave these grants intact.
-			// It does not matter whether this is on a database or a schema.
-			continue
-		}
-		// If we are still here, this grant is a candidate for being revoked
-		pd.toRevokeObjects = append(pd.toRevokeObjects, g)
-	}
-	return nil
-}
-
 func (pd *ProductDTAP) grant_(ctx context.Context, semCnf *semantics.Config, cnf *Config, conn *sql.DB, productRoles map[ProductRole]struct{},
 	grupinDisjointFromObject func(semantics.Ident, semantics.Ident, semantics.Ident) bool,
 	userManagedOwners func(semantics.ProductDTAPID) map[semantics.Ident]struct{}, c *accountCache) error {
@@ -337,17 +272,6 @@ func (pd *ProductDTAP) grant_(ctx context.Context, semCnf *semantics.Config, cnf
 		}
 	}
 	if err := DoGrants(ctx, cnf, conn, pd.getToDoGrantsToDBRoles()); err != nil {
-		return err
-	}
-
-	// Finally, let's query the product read role for any spurious object privileges sysadmins
-	// may have granted it: privileges in scope for grupr, but, granted to the wrong role.
-	if err := pd.setGrantActionsFutureObjectsReadRole(ctx, cnf, conn, productRoles); err != nil {
-		return err
-	}
-
-	// Now, regular grants 
-	if err := pd.setGrantActionsObjectsReadRole(ctx, cnf, conn, grupinDisjointFromObject, productRoles); err != nil {
 		return err
 	}
 

--- a/internal/snowflake/product_dtap__objects.go
+++ b/internal/snowflake/product_dtap__objects.go
@@ -82,81 +82,9 @@ func (pd *ProductDTAP) setGrantActionsFutureObjectsWriteRole(ctx context.Context
 						if dbObjs, ok := pd.Interface.aggAccountObjects.DBs[g.Database]; ok {
 							dbObjs.setFutureGrantTo(ModeWrite, g)
 						}
-						// If we did not match the object, there are two possibilities:
-						// 1. The schema was created after we matched objects, but before we queried future grants on
-						// the write role.
-						// 2. Despite the fact that the grant_on column matches our grant template, the object is not of
-						// a kind that grupr is managing after all. 
-						//
-						// Case 2 is more likely to occur. This is at the moment the case with tables in 
-						// imported databases (like SNOWFLAKE_SAMPLE_DATA) and views in applications, as in
-						// SNOWFLAKE.ACCOUNT_USAGE.ACCESS_HISTORY). When scanning for objects, we currently only
-						// consider standard databases.
-						// So when users grant privileges on objects in such databases to the product role,
-						// but they are not matched by the YAML, then, currently, we drop them.
-						// If you want grupr to retain such grants, you should include them in the YAML.
-						// But if you want multiple product roles to have, say, select privileges on such an object,
-						// you would have to add the same object to the YAML of two different products, and you can't
-						// do that in grupr. So, this is an example where you would really get stuck if you used grupr.
-						// Unless, prior to revoking, we try once more if we can find the object; and then if not,
-						// then we conclude it was not a managed object, and therefore the grant is not managed.
-						//
-						// Consumer accounts lack privileges to grant privileges on individual objects in imported
-						// databases to roles. They can only grant usage on database roles in the exported database that
-						// exists in the producer account. Or they can grant IMPORTED PRIVILEGES and then the whole
-						// share is accessible to the grantee. Grants on individual objects in the imported database
-						// nevertheless show up in the output of SHOW GRANTS.
-						//
-						// The Snowflake datbase shows up as 'APPLICATION' in the output of SHOW DATABASES, but 
-						// is also an imported database and privilges on it can be granted to other roles in the same way.
-						// Grants on objects do show up in the output of SHOW GRANTS. A lot of them, especially if
-						// sysadmins granted IMPORTED PRIVILEGES.
-						//
-						// As of now grupr cannot grant privileges on objects in imported databases. To do so would
-						// require Snowflake specific YAML in which imported databases and their database roles are
-						// mentioned and can be granted to product (roles) explicitly. Until we get there, however,
-						// we need a way for grupr to ignore such grants. I see two ways, broadly:
-						//
-						// 1. Query explicitly for databases of types APPLICATION and IMPORTED DATABASE, and whenever
-						// we are processing the output of SHOW GRANTS, and the Databsase field of a grant equals 
-						// an imported database, ignore it, and skip to the next one (or even alter the SHOW GRANTS
-						// query to filter out such records server-side).
-						//
-						// 2. Like we do now, ignore everything but STANDARD databases when we query for databases.
-						// When people put YAML that matches such objects, no matching objects will be found.
-						// When we process the output of SHOW GRANTS, objects from other types of databases will
-						// either be ignored (if they are matched by the YAML), or, if they are not matched (more
-						// likely, reflecting correct YAML), then they will be a revoke candidate. However, prior
-						// to revoking, it will be checked if the object can be found using the same machinery
-						// (account cache) as was used to match objects in the YAML. Then, if the object can not
-						// be found, it will be regarded as an object that grupr apparently does not yet manage.
-						//
-						// The pro of method 2 is that it does not require us to model stuff we do not yet support.
-						// Snowflake can at any moment introduce yet new types of databases, schemas, and objects.
-						// Having a way to just use the way we normally get information on objects also when processing
-						// the output of SHOW GRANTS will give some piece of mind that grupr will less frequently 
-						// and less urgently need updatting.
-						// But it does come with a performance hit. We will be processing all this output from
-						// show grants. And some additional SHOW TABLES / VIEWS commands will be fired.
-						// Also, if we go with method 2, it will mean that there can be unmanaged grants hiding
-						// even in the results for our query for managed grants only.
-						// Fortunately, when it comes to our database roles, they will not have any such grants.
-						// So in that respect, no great code change is needed.
-						// Okay, so, we go with method 2, then.
-						//
-						// But, hey, no role would get CREATE on an imported database.
-						// And, SELECT rights, we exclusively manage them via DATABASE roles.
-						// So, we have no problem! We would ignore SELECT grants anyway, when they are
-						// granted to product roles, be they read roles or write roles.
-						// Any privileges that we do manage on behalf of product roles would never be granted
-						// directly on either imported or application databases--at least at the moment (May 2026).
 						continue
 					}
-				case PrvUsage, PrvMonitor:
-					// Grupr does not normally assign these privileges, but sysadmins are encouraged to do so in case
-					// they want to grant privileges on objects in schemas to the write role that grupr does not (yet)
-					// manage. For that reason, we will leave these grants intact.
-					continue
+					// We should revoke
 				}
 			}
 		}
@@ -174,7 +102,7 @@ func (pd *ProductDTAP) setGrantActionsObjectsWriteRole(ctx context.Context, cnf 
 	if _, ok := productRoles[pd.WriteRole]; !ok && cnf.DryRun {
 		return nil
 	}
-	for g, err := range QueryGrantsToRoleFiltered(ctx, cnf, conn, pd.WriteRole.ID, cnf.ObjectPrivileges, nil) {
+	for g, err := range QueryGrantsToRoleFiltered(ctx, cnf, conn, pd.WriteRole.ID, cnf.ObjectPrivilegesOwnership, nil) {
 		if err != nil {
 			return err
 		}
@@ -203,13 +131,6 @@ func (pd *ProductDTAP) setGrantActionsObjectsWriteRole(ctx context.Context, cnf 
 				pd.toTransferOwnership = append(pd.toTransferOwnership, g)
 			}
 			continue // There is no revoking ownersip, so, continue either way
-		case PrvUsage, PrvMonitor:
-			// Grupr does not normally assign these privileges, but sysadmins are encouraged to do so in case
-			// they want to grant privileges on objects in schemas to the write role that grupr does not (yet)
-			// manage. For that reason, we will leave these grants intact.
-			//
-			// Note that it does not matter if usage / monitor was granted on a database or a schema.
-			continue
 		}
 		// If we are still here, this grant is a candidate for being revoked
 		pd.toRevokeObjects = append(pd.toRevokeObjects, g)
@@ -396,11 +317,13 @@ func (pd *ProductDTAP) getTodoGrantsFutureObjectsWriteRole(map[ObjType]bool mots
 	return func(yield func(FutureGrant) bool) {
 		for db, dbObjs := range pd.Interface.aggAccountObjects.DBs {
 			if dbObjs.MatchAllSchemas {
-				prvs := []PrivilegeComplete{}
 				candidatePrvs := []PrivilegeComplete{}
 				for ot := range mots {
 					candidatePrvs = append(candidatePrvs, PrivilegeComplete{Privilege: PrvCreate, CreateObjectType: ot})
 				}
+				// We do not grant future ownership, the product write role will already have ownership after creating
+				// objects
+				prvs := []PrivilegeComplete{}
 				for _, pc := range candidatePrvs {
 					if !dbObjs.hasFutureGrantTo(ModeWrite, ObjTpSchema, pc) {
 						prvs = append(prvs, pc)
@@ -427,11 +350,11 @@ func (pd *ProductDTAP) getToDoGrantsObjectsWriteRole(map[ObjType]bool mots) iter
 	return func(yield func(Grant) bool) {
 		for db, dbObjs := range pd.Interface.aggAccountObjects.DBs {
 			for schema, schemaObjs := range dbObjs.Schemas {
-				prvs := []PrivilegeComplete{}
 				candidatePrvs := []PrivilegeComplete{}
 				for ot := range mots {
 					candidatePrvs = append(candidatePrvs, PrivilegeComplete{Privilege: PrvCreate, CreateObjectType: ot})
 				}
+				prvs := []PrivilegeComplete{}
 				for _, pc := range candidatePrvs {
 					if !schemaObjs.hasGrantTo(ModeWrite, pc) {
 						prvs = append(prvs, pc)

--- a/internal/snowflake/product_dtap__objects.go
+++ b/internal/snowflake/product_dtap__objects.go
@@ -145,6 +145,8 @@ func (pd *ProductDTAP) setGrantActionsObjectsWriteRole(ctx context.Context, cnf 
 			// Grupr does not normally assign these privileges, but sysadmins are encouraged to do so in case
 			// they want to grant privileges on objects in schemas to the write role that grupr does not (yet)
 			// manage. For that reason, we will leave these grants intact.
+			//
+			// Note that it does not matter if usage / monitor was granted on a database or a schema.
 			continue
 		}
 		// If we are still here, this grant is a candidate for being revoked
@@ -241,7 +243,7 @@ func (pd *ProductDTAP) setGrantActionsObjectsReadRole(ctx context.Context, cnf *
 		if err != nil {
 			return err
 		}
-		switch pc := g.Privileges[0]; pc.Privilege {
+		switch g.Privileges[0].Privilege {
 		case PrvOwnership:
 			if grupinDisjointFromObject(g.Database, g.Schema, g.Object) {
 				// There will be no other product claiming ownership of this object, we need to
@@ -254,6 +256,7 @@ func (pd *ProductDTAP) setGrantActionsObjectsReadRole(ctx context.Context, cnf *
 			// Grupr does not normally assign these privileges, but sysadmins are encouraged to do so in case
 			// they want to grant privileges on objects in schemas to the write role that grupr does not (yet)
 			// manage. For that reason, we will leave these grants intact.
+			// It does not matter whether this is on a database or a schema.
 			continue
 		}
 		// If we are still here, this grant is a candidate for being revoked

--- a/internal/snowflake/product_dtap__objects.go
+++ b/internal/snowflake/product_dtap__objects.go
@@ -66,7 +66,7 @@ func (pd *ProductDTAP) setGrantActionsFutureObjectsWriteRole(ctx context.Context
 	if _, ok := productRoles[pd.WriteRole]; !ok && cnf.DryRun {
 		return nil
 	}
-	for g, err := range QueryFutureGrantsToRoleFiltered(ctx, conn, pd.WriteRole.ID,	cnf.ObjectPrivilegesOwnership, nil) {
+	for g, err := range QueryFutureGrantsToRoleFiltered(ctx, conn, pd.WriteRole.ID, cnf.ObjectPrivilegesOwnership, nil) {
 		if err != nil {
 			return err
 		}
@@ -148,7 +148,7 @@ func (pd *ProductDTAP) setUserManagedOwnersOfObjects(semCnf *semantics.Config, c
 					continue
 				}
 				if strings.HasPrefix(string(aggObjAttr.Owner), string(semCnf.Prefix)) {
-					r, err := newProductRoleFromIdent(semCnf, aggObjAttr.Owner); {
+					r, err := newProductRoleFromIdent(semCnf, aggObjAttr.Owner)
 					if err != nil {
 						// In this case, it would have to be a database role, or else other roles
 						// exist sharing the grupr prefix, this would be a good reason to crash
@@ -158,7 +158,7 @@ func (pd *ProductDTAP) setUserManagedOwnersOfObjects(semCnf *semantics.Config, c
 						// Okay, so it was a database role that owned the object. Not something sysadmins
 						// should have done. Not something grupr would do. But we'll just not add any
 						// previous user managed owning roles. Ownership of the object will be sorted out
-						// for this object cause it was matched by this product: the write role will 
+						// for this object cause it was matched by this product: the write role will
 						// claim ownership of it.
 					}
 					if r.Mode == ModeWrite && (r.ProductID != pd.ProductID || r.DTAP != pd.DTAP) {
@@ -313,7 +313,7 @@ func (pd *ProductDTAP) revoke_(ctx context.Context, cnf *Config, conn *sql.DB) e
 	return nil
 }
 
-func (pd *ProductDTAP) getTodoGrantsFutureObjectsWriteRole(map[ObjType]bool mots) iter.Seq[FutureGrant] {
+func (pd *ProductDTAP) getTodoGrantsFutureObjectsWriteRole(mots map[ObjType]bool) iter.Seq[FutureGrant] {
 	return func(yield func(FutureGrant) bool) {
 		for db, dbObjs := range pd.Interface.aggAccountObjects.DBs {
 			if dbObjs.MatchAllSchemas {
@@ -346,7 +346,7 @@ func (pd *ProductDTAP) getTodoGrantsFutureObjectsWriteRole(map[ObjType]bool mots
 	}
 }
 
-func (pd *ProductDTAP) getToDoGrantsObjectsWriteRole(map[ObjType]bool mots) iter.Seq[Grant] {
+func (pd *ProductDTAP) getToDoGrantsObjectsWriteRole(mots map[ObjType]bool) iter.Seq[Grant] {
 	return func(yield func(Grant) bool) {
 		for db, dbObjs := range pd.Interface.aggAccountObjects.DBs {
 			for schema, schemaObjs := range dbObjs.Schemas {
@@ -424,7 +424,7 @@ func (pd *ProductDTAP) getToDoOwnershipGrants() iter.Seq[Grant] {
 	}
 }
 
-func (pd *ProductDTAP) getToDoFutureGrantsToDBRoles(map[ObjType]bool mots) iter.Seq[FutureGrant] {
+func (pd *ProductDTAP) getToDoFutureGrantsToDBRoles(mots map[ObjType]bool) iter.Seq[FutureGrant] {
 	return func(yield func(FutureGrant) bool) {
 		if !pd.Interface.pushToDoFutureGrants(yield, mots) {
 			return

--- a/internal/snowflake/product_dtap__objects.go
+++ b/internal/snowflake/product_dtap__objects.go
@@ -80,7 +80,7 @@ func (pd *ProductDTAP) setGrantActionsFutureObjectsWriteRole(ctx context.Context
 					if pd.Interface.ObjectMatchers.MatchAllSchemasInDB(g.Database) {
 						// If yes, then, if we also have matched the object, mark on it that privilege on future objects was already granted
 						if dbObjs, ok := pd.Interface.aggAccountObjects.DBs[g.Database]; ok {
-							dbObjs.setFutureGrantTo(ModeWrite, g)
+							pd.Interface.aggAccountObjects.DBs[g.Database] = dbObjs.setFutureGrantTo(ModeWrite, g) // value semantics
 						}
 						continue
 					}

--- a/internal/snowflake/product_dtap__objects.go
+++ b/internal/snowflake/product_dtap__objects.go
@@ -320,7 +320,7 @@ func (pd *ProductDTAP) grant_(ctx context.Context, semCnf *semantics.Config, cnf
 			return err
 		}
 	}
-	if err := DoFutureGrants(ctx, cnf, conn, pd.getToDoFutureGrantsToDBRoles()); err != nil {
+	if err := DoFutureGrants(ctx, cnf, conn, pd.getToDoFutureGrantsToDBRoles(cnf.ManagedObjTypes)); err != nil {
 		return err
 	}
 
@@ -392,16 +392,16 @@ func (pd *ProductDTAP) revoke_(ctx context.Context, cnf *Config, conn *sql.DB) e
 	return nil
 }
 
-func (pd *ProductDTAP) getTodoGrantsFutureObjectsWriteRole() iter.Seq[FutureGrant] {
+func (pd *ProductDTAP) getTodoGrantsFutureObjectsWriteRole(map[ObjType]bool mots) iter.Seq[FutureGrant] {
 	return func(yield func(FutureGrant) bool) {
 		for db, dbObjs := range pd.Interface.aggAccountObjects.DBs {
 			if dbObjs.MatchAllSchemas {
 				prvs := []PrivilegeComplete{}
-				for _, pc := range [2]PrivilegeComplete{
-					PrivilegeComplete{Privilege: PrvCreate, CreateObjectType: ObjTpTable},
-					PrivilegeComplete{Privilege: PrvCreate, CreateObjectType: ObjTpView},
-					PrivilegeComplete{Privilege: PrvCreate, CreateObjectType: ObjTpMaterializedView},
-				} {
+				candidatePrvs := []PrivilegeComplete{}
+				for ot := range mots {
+					candidatePrvs = append(candidatePrvs, PrivilegeComplete{Privilege: PrvCreate, CreateObjectType: ot})
+				}
+				for _, pc := range candidatePrvs {
 					if !dbObjs.hasFutureGrantTo(ModeWrite, ObjTpSchema, pc) {
 						prvs = append(prvs, pc)
 					}
@@ -423,16 +423,16 @@ func (pd *ProductDTAP) getTodoGrantsFutureObjectsWriteRole() iter.Seq[FutureGran
 	}
 }
 
-func (pd *ProductDTAP) getToDoGrantsObjectsWriteRole() iter.Seq[Grant] {
+func (pd *ProductDTAP) getToDoGrantsObjectsWriteRole(map[ObjType]bool mots) iter.Seq[Grant] {
 	return func(yield func(Grant) bool) {
 		for db, dbObjs := range pd.Interface.aggAccountObjects.DBs {
 			for schema, schemaObjs := range dbObjs.Schemas {
 				prvs := []PrivilegeComplete{}
-				for _, pc := range [2]PrivilegeComplete{
-					PrivilegeComplete{Privilege: PrvCreate, CreateObjectType: ObjTpTable},
-					PrivilegeComplete{Privilege: PrvCreate, CreateObjectType: ObjTpView},
-					PrivilegeComplete{Privilege: PrvCreate, CreateObjectType: ObjTpMaterializedView},
-				} {
+				candidatePrvs := []PrivilegeComplete{}
+				for ot := range mots {
+					candidatePrvs = append(candidatePrvs, PrivilegeComplete{Privilege: PrvCreate, CreateObjectType: ot})
+				}
+				for _, pc := range candidatePrvs {
 					if !schemaObjs.hasGrantTo(ModeWrite, pc) {
 						prvs = append(prvs, pc)
 					}
@@ -478,6 +478,11 @@ func (pd *ProductDTAP) getToDoOwnershipGrants() iter.Seq[Grant] {
 			for schema, schemaObjs := range dbObjs.Schemas {
 				for obj, objAttr := range schemaObjs.Objects {
 					if !objAttr.isOwnedByProductWriteRole {
+						ot = objAttr.ObjectType
+						if ot == ObjTpHybridTable {
+							// In snowflake GRANT <privileges> ..., HYBRID TABLE is not a recongnized object type
+							ot = ObjTpTable
+						}
 						if !yield(Grant{
 							Privileges:    []PrivilegeComplete{PrivilegeComplete{Privilege: PrvOwnership}},
 							GrantedOn:     objAttr.ObjectType,
@@ -496,13 +501,13 @@ func (pd *ProductDTAP) getToDoOwnershipGrants() iter.Seq[Grant] {
 	}
 }
 
-func (pd *ProductDTAP) getToDoFutureGrantsToDBRoles() iter.Seq[FutureGrant] {
+func (pd *ProductDTAP) getToDoFutureGrantsToDBRoles(map[ObjType]bool mots) iter.Seq[FutureGrant] {
 	return func(yield func(FutureGrant) bool) {
-		if !pd.Interface.pushToDoFutureGrants(yield) {
+		if !pd.Interface.pushToDoFutureGrants(yield, mots) {
 			return
 		}
 		for _, i := range pd.Interfaces {
-			if !i.pushToDoFutureGrants(yield) {
+			if !i.pushToDoFutureGrants(yield, mots) {
 				return
 			}
 		}

--- a/internal/snowflake/product_dtap__objects.go
+++ b/internal/snowflake/product_dtap__objects.go
@@ -60,7 +60,9 @@ func (pd *ProductDTAP) recalcObjects() {
 	pd.Interface.aggregate() // we needed to hold on to AccountObjs by ObjExpr until we derived all interface objects
 }
 
-func (pd *ProductDTAP) setFutureGrantsToWriteRole(ctx context.Context, cnf *Config, conn *sql.DB, productRoles map[ProductRole]struct{}) error {
+func (pd *ProductDTAP) setGrantActionsFutureObjectsWriteRole(ctx context.Context, cnf *Config, conn *sql.DB, productRoles map[ProductRole]struct{}) error {
+	// This function covers setting the todo and already done actions regarding privileges on future objects for the product write role
+	// It does not cover compute privileges, and it does not cover usage of database roles.
 	if _, ok := productRoles[pd.WriteRole]; !ok && cnf.DryRun {
 		return nil
 	}
@@ -68,7 +70,6 @@ func (pd *ProductDTAP) setFutureGrantsToWriteRole(ctx context.Context, cnf *Conf
 		if err != nil {
 			return err
 		}
-
 		switch g.GrantedIn {
 		case ObjTpDatabase:
 			switch g.GrantedOn {
@@ -81,27 +82,33 @@ func (pd *ProductDTAP) setFutureGrantsToWriteRole(ctx context.Context, cnf *Conf
 						if dbObjs, ok := pd.Interface.aggAccountObjects.DBs[g.Database]; ok {
 							dbObjs.setFutureGrantTo(ModeWrite, g)
 						}
-					} else {
-						// if not, then revoke this future grant
-						//
-						// Note that when we refreshed, we reset toRevokeFutureObjects to the empty slice
-						pd.toRevokeFutureObjects = append(pd.toRevokeFutureObjects, g)
+						// If we did not match the object, there are two possibilities:
+						// 1. The schema was created after we matched objects, but before we queried future grants on
+						// the write role.
+						// 2. Despite the fact that the grant_on column matches our grant template, the object is not of
+						// a kind that grupr is managing after all. At the moment, that should not occur, but it may
+						// occur in the future as Snowflake is changing continuously. 
+						// In both cases, it would be okay to leave the grant intact.
+						continue
 					}
-				default:
-					pd.toRevokeFutureObjects = append(pd.toRevokeFutureObjects, g)
+				case PrvUsage, PrvMonitor:
+					// Grupr does not normally assign these privileges, but sysadmins are encouraged to do so in case
+					// they want to grant privileges on objects in schemas to the write role that grupr does not (yet)
+					// manage. For that reason, we will leave these grants intact.
+					continue
 				}
-			default:
-				pd.toRevokeFutureObjects = append(pd.toRevokeFutureObjects, g)
 			}
-		default:
-			pd.toRevokeFutureObjects = append(pd.toRevokeFutureObjects, g)
 		}
+		// If we are still here, this grant will be a revoke candidate.
+		pd.toRevokeFutureObjects = append(pd.toRevokeFutureObjects, g)
 	}
 	return nil
 }
 
-func (pd *ProductDTAP) setGrantsToWriteRole(ctx context.Context, cnf *Config, conn *sql.DB,
+func (pd *ProductDTAP) setGrantActionsObjectsWriteRole(ctx context.Context, cnf *Config, conn *sql.DB,
 	grupinDisjointFromObject func(semantics.Ident, semantics.Ident, semantics.Ident) bool, productRoles map[ProductRole]struct{}) error {
+	// This function covers setting the todo and already done actions regarding privileges on objects for the product write role
+	// It does not cover compute privileges, and it does not cover usage of database roles.
 	if _, ok := productRoles[pd.WriteRole]; !ok && cnf.DryRun {
 		return nil
 	}
@@ -111,193 +118,37 @@ func (pd *ProductDTAP) setGrantsToWriteRole(ctx context.Context, cnf *Config, co
 		}
 		switch pc := g.Privileges[0]; pc.Privilege {
 		case PrvCreate:
-			switch pc.CreateObjectType {
-			case ObjTpTable, ObjTpView:
-				if !pd.Interface.ObjectMatchers.DisjointFromSchema(g.Database, g.Schema) {
-					if dbObjs, ok := pd.Interface.aggAccountObjects.DBs[g.Database]; ok {
-						if schemaObjs, ok := dbObjs.Schemas[g.Schema]; ok {
-							dbObjs.Schemas[g.Schema] = schemaObjs.setGrantTo(ModeWrite, g)
-						}
+			if !pd.Interface.ObjectMatchers.DisjointFromSchema(g.Database, g.Schema) {
+				if dbObjs, ok := pd.Interface.aggAccountObjects.DBs[g.Database]; ok {
+					if schemaObjs, ok := dbObjs.Schemas[g.Schema]; ok {
+						dbObjs.Schemas[g.Schema] = schemaObjs.setGrantTo(ModeWrite, g)
 					}
-					// ignore, we did not match the object last time we refreshed, but the grant is fine, we leave it
-				} else {
-					// Note that when we refreshed, toRevokeObjects was reset to an empty slice
-					pd.toRevokeObjects = append(pd.toRevokeObjects, g)
 				}
+				// Whether or not we actually found the schema in the database, the grant is fine
+				continue
 			}
-			// Ignore; unmanaged grant
 		case PrvOwnership:
-			switch g.GrantedOn {
-			case ObjTpTable, ObjTpView:
-				if !pd.Interface.ObjectMatchers.DisjointFromObject(g.Database, g.Schema, g.Object) {
-					if schemaObjs, ok := pd.Interface.aggAccountObjects.GetSchema(g.Database, g.Schema); ok {
-						if aggObjAttr, ok := schemaObjs.Objects[g.Object]; ok {
-							schemaObjs.Objects[g.Object] = aggObjAttr.setGrantTo(ModeWrite, g)
-						}
+			if !pd.Interface.ObjectMatchers.DisjointFromObject(g.Database, g.Schema, g.Object) {
+				if schemaObjs, ok := pd.Interface.aggAccountObjects.GetSchema(g.Database, g.Schema); ok {
+					if aggObjAttr, ok := schemaObjs.Objects[g.Object]; ok {
+						schemaObjs.Objects[g.Object] = aggObjAttr.setGrantTo(ModeWrite, g)
 					}
-				} else if grupinDisjointFromObject(g.Database, g.Schema, g.Object) {
-					// There will be no other product claiming ownership of this object, we need to
-					// transfer its ownership to a role that is not managed by grupr.
-					// Note that when we refreshed, toTransferOwnership was reset to an empty slice
-					pd.toTransferOwnership = append(pd.toTransferOwnership, g)
-					// WIP: We don't want to transfer ownership on unmanaged objects like dynamic tables!?
-					// even if they are disjoint from the grupin?! cause it would be like altering an
-					// unmanaged grant. How to distinguish in this case between regular tables disjoint
-					// from the grupin, and, say, external, event, hybrid, etc tables? Perhaps there will
-					// be no other way than to do another, ad hoc, query, to find out.
-					// Even that is not simple, however, because the way to query it depends on what it is,
-					// so that would be a piece of code that would have to try different kinds of strategies
-					// until it finds something. e.g., try DESCRIBE TABLE, then try DESCRIBE DYNAMIC TABLE, etc.
-					// Or do a SHOW OBJECTS, covering regular, hybrid, dynamic, and iceberg tables, and then
-					// if you still don't find it, do external tables, event tables, interactive tables, online feature
-					// tables, directory tables, etc. Actually, many of those would probably occur in the output
-					// of SHOW OBJECTS; only, it would not be possible to tell them apart from regular, normal tables.
-					// Unfortunately, the output does not contain a column "is_normal".
-					// Perhaps in our account cache we should actually keep all kinds of tables there are,
-					// so that we do have all the info, even if we are not managing grants on such types of
-					// objects yet.
-					// If we did that, it would be nice to have ObjType values for each kind, the only trouble
-					// is that when we query for grants in Snowflake, Snowflake will always just say TABLE,
-					// so when we deserialize a row like that, it would contain erroneous data. But, we'll just
-					// have to take that into account, then. Actually, it's worse, for like a hybrid table
-					// the granted_on column would just show TABLE, but, for example, for an interactive table,
-					// there is an example in the docs where it shows as "INTERACTIVE_TABLE". Unfortunately,
-					// the documentation does not provide an exhaustive list of possible values.
-					//
-					// And what about secure views, materialized views, and semantic views?
-					//
-					// You know, the Snowflake APIs for creating objects and querying grants on them have
-					// some inconsistencies, probably due to the speed with which new features are added and
-					// launched. That makes it harder for a tool like grupr to achieve consistent access management
-					// in a simple manner.
-					// Because the SHOW GRANTS APIs treat everything as a table, when I am now transfering ownership
-					// away, I am already managing grants on object types I do not manage. Managing all object types
-					// would make the code only simpler, actually, if a lot longer.
-
-					// TDOD what about interactive warehouses :-) I suppose grupr should add all interactive tables
-					// to all interactive warehouses that have been granted to either the product roles or product
-					// roles of consumers. And of course remove the tables if usage grants on those warehouses change
-
-					// Okay, so these Snowflake APIs are a bit of a mess actually, too bad. It's not even possible to
-					// query only "normal" tables and "normal" views. We can try something here:
-					// what if we say that, you know, if you have a grant here on an object that you don't match,
-					// in the YAML, that's already enough to revoke it, no matter what it is. And yes, even if
-					// that's ownership, you revoke it, which you do by transferring it, in this case. So, in this
-					// case, yes, we chose to risk to break something: we just have to say: please don't grant anything
-					// on an object to a grupr managed role unless it's matched by the relevant object expressions.
-					// and if you change those expressions, or if you change the name of a product or interface, be
-					// aware that those grants will be revoked.
-					// Okay, and, if we have a grant here, and it is on an object matched by the YAML, but, we
-					// did not find it, then maybe it is because SHOW objects did not return this type of object,
-					// (the documentation is not clear on exactly what is and is not returned), and therefore,
-					// by accident, by this circumstance, grupr does not support this type of object yet, and
-					// therefore we will leave the grant be.
-					// Okay, so now, if we try to live with not knowing the object type, then we should think about
-					// what to grant. Read privileges first. SELECT will always be okay. REFERENCES is not supported for dynamic tables and
-					// online feature tables. MONITOR is only relevant for certain types of tables, we might omit
-					// it altogether, if you want to enable people to monitor, say, a dynamic table, you are out of luck
-					// and you have to do it yourself. Now in this case, we should not revoke this privilege if it was
-					// there.
-					// For write privileges, we do need to revoke everything: except ownership, which is valid for all
-					// types of objects.
-					// You know, even if it may be very painful to write all the queries necessary to figure out exactly
-					// the type of object for each and every object, it would make reasoning about correctness of the
-					// code a lot easier if we made a decent attempt at exactly that.
-
-					// ouch, you know, when it would come to implement the ability to manage grants on objects
-					// exclusively, we will have to query grants on objects. And to do that, we'd definitely need
-					// to know the type of each object.
-					// Oh, wow, just created a hybrid table, and then queried the grants on it with these queries:
-					// - show grants on table x.y.z --works;
-					// - show grants on hybrid table x.y.z --error;
-					// - show grants on dynamic table x.y.z --works;
-					// - show grants on iceberg table x.y.z --works;
-					// - show grants on interactive table x.y.z --works;
-					// - show grants on external table x.y.z --works;
-					// - show grants on online feature table x.y.z --works;
-					//
-					// Not only is it completely undocumented for this statement what the valid object types are,
-					// the statement also fails to check whether the object is actually of the specified type.
-					//
-					// But, I guess, as Snowflake matures, eventually, eventually, they will correct their APIs,
-					// and, we should aim to use the correct statements.
-					// Already, as of Apr 2026, the GRANT statement is much more explicit about the possible schema level 
-					// object types: https://docs.snowflake.com/en/sql-reference/sql/grant-privilege
-					//
-					// We would be supporting, initially:
-					//
-					// DYNAMIC TABLE
-					// EVENT TABLE
-					// EXTERNAL TABLE
-					// ICEBERG TABLE
-					// INTERACTIVE TABLE
-					// MATERIALIZED VIEW
-					// ONLINE FEATURE TABLE
-					// SEMANTIC VIEW
-					// TABLE
-					// VIEW
-					//
-					// All of these are just tables and views, really, and that's what people would expect to
-					// be able to manage with a tool like grupr.
-					// Even just to correctly issue GRANT and REVOKE statements for these types of objects,
-					// many of which are already returned by SHOW OBJECTS (probably ;-)), we need to know
-					// the exact object type
-					// And we need to find out as well how these object types are represented in the output
-					// of SHOW GRANTS commands, I've seen myself that HYBRID TABLE is just represented as TABLE,
-					// while an INTERACTIVE TABLE is represented as INTERACTIVE_TABLE. HYBRID TABLE is also
-					// not a valid object_type in the GRANT TO ROLE statement. DYNAMIC TABLE is. Can we expect
-					// that the latter would appear as DYNAMIC_TABLE?
-					// So to validate this, we'd have no other way than to just create at least one example
-					// of each kind of table and view, hopefully the set-up costs won't be too high for any of
-					// them, but it will certainly take some time to figure out how, at this moment, in all
-					// the various "official" and partially documented APIs and output each of them is
-					// represented, if at all.
-					//
-					// We could also try to limit ourselves first and say we only manage normal tables, but
-					// even then we need to establish how to query only normal tables; sadly SHOW OBJECTS does
-					// not have a column "is_normal", and neither does "SHOW TABLES". Querying the information
-					// schema there is something called "BASE TABLE", but it might be referring to a slightly
-					// different distinction, and it is an entirely different API than what we have been using
-					// so far. The Snowflake REST API also mentions a table type "NORMAL", but, that API comes
-					// with its own quirks as well. Anyway, I gave some feedback on the Snowflake docs,
-					// and, am calling it a day.
-
-					// SOLUTION, WIP:
-					// We will process candidate objects for transferring ownership as follows:
-					// - for all schema's in the collection of to transfer objects, create a matching expression,
-					// - use the matching expressions to query the account cache
-					// - if the objects are subsequently found in the account cache, they are of a type that
-					//   is in scope for grupr normally, and ownership can be transferred.
-					// - if the objects are subsequently not found in the account cache, they are of a type
-					//   for which grupr is not (yet) managing privileges, in this case, sysadmins must have
-					//   granted the privilege using other means, and grupr will not revoke it and not
-					//   transfer ownership.
-					// We will treat revoke candidates the same way.
 				}
+			} else if grupinDisjointFromObject(g.Database, g.Schema, g.Object) {
+				// There will be no other product claiming ownership of this object, we need to
+				// transfer its ownership to a role that is not managed by grupr.
+				// Note that when we refreshed, toTransferOwnership was reset to an empty slice
+				pd.toTransferOwnership = append(pd.toTransferOwnership, g)
 			}
-			// Ignore, unmanaged grant
+			continue // There is no revoking ownersip, so, continue either way
+		case PrvUsage, PrvMonitor:
+			// Grupr does not normally assign these privileges, but sysadmins are encouraged to do so in case
+			// they want to grant privileges on objects in schemas to the write role that grupr does not (yet)
+			// manage. For that reason, we will leave these grants intact.
+			continue
 		}
-		case PrvInsert, PrvUpdate, PrvTruncate, PrvDelete, PrvEvolveSchema, PrvApplyBudget,
-        	PrvSelect, PrvSelectErrorTable, PrvReferences:
-			switch g.GrantedOn {
-			case ObjTpTable, ObjTpView:
-				// We revoke this grant, as it is redundant in grupr it's access management model. But, we need to check
-				// if we found the object in question, before we revoke: this could be a dynamic, event, external,
-				// hybrid, or iceberg table, which we do not manage yet; we leave unmanaged grants intact not to break
-				// anything.
-				// 
-				// If this is a regular table or view, and we did not find it, it means the object was created after we
-				// refreshed objects, and then some of these privileges were granted.  So if we do not have the table in
-				// our accountobjects in memory, we have no way of knowing for sure whether or not this is a type of
-				// table we don't support yet (dynamic, iceberg, hybrid, event, external, ...) Therefore, we will not
-				// revoke in that case also. If it was a regular table, the next time grupr runs, the object will be
-				// found, and the privilege revoked.
-				if _, ok := pd.Interface.aggAccountObjects.GetObject(g.Database, g.Schema, g.Object); ok {
-					pd.toRevokeObjects = append(pd.toRevokeObjects, g)
-				}
-			}
-			// Ignore
-		// Ignore; unmanaged grant
+		// If we are still here, this grant is a candidate for being revoked
+		pd.toRevokeObjects = append(pd.toRevokeObjects, g)
 	}
 	return nil
 }
@@ -305,37 +156,108 @@ func (pd *ProductDTAP) setGrantsToWriteRole(ctx context.Context, cnf *Config, co
 func (pd *ProductDTAP) setUserManagedOwnersOfObjects(semCnf *semantics.Config, cnf *Config,
 	userManagedOwners func(semantics.ProductDTAPID) map[semantics.Ident]struct{}) error {
 	pd.userManagedOwnersOfObjects = map[semantics.Ident]struct{}{}
-	for _, dbObjs := range pd.Interface.aggAccountObjects.DBs {
+	for db, dbObjs := range pd.Interface.aggAccountObjects.DBs {
 		for _, schemaObjs := range dbObjs.Schemas {
 			for _, aggObjAttr := range schemaObjs.Objects {
 				if slices.Contains(cnf.SystemDefinedRoles, aggObjAttr.Owner) {
 					continue
 				}
 				if strings.HasPrefix(string(aggObjAttr.Owner), string(semCnf.Prefix)) {
-					if r, err := newProductRoleFromString(semCnf, aggObjAttr.Owner); err != nil {
-						return err
-					} else {
-						if r.Mode != ModeWrite {
-							return fmt.Errorf("object was granted to grupr managed role '%v', which is not a write role, please check", r.ID)
+					r, err := newProductRoleFromIdent(semCnf, aggObjAttr.Owner); {
+					if err != nil {
+						// In this case, it would have to be a database role, or else other roles
+						// exist sharing the grupr prefix, this would be a good reason to crash
+						if _, err = newDatabaseRoleFromString(semCnf, db, aggObjAttr.Owner); err != nil {
+							return err
 						}
-						// It's a write role
-						if r.ProductID != pd.ProductID || r.DTAP != pd.DTAP {
-							// So, another write role owned this object before, we need to check what user managed roles
-							// have been granted this other write role; they would lose ownership of the object if we
-							// would claim it; so we need to grant our write role to those user managed roles, if any
-							for curOwner := range userManagedOwners(semantics.ProductDTAPID{ProductID: r.ProductID, DTAP: r.DTAP}) {
-								pd.userManagedOwnersOfObjects[curOwner] = struct{}{}
-							}
-							continue
-						}
-						// We own this object, all good here, move on.
-						continue
+						// Okay, so it was a database role that owned the object. Not something sysadmins
+						// should have done. Not something grupr would do. But we'll just not add any
+						// previous user managed owning roles. Ownership of the object will be sorted out
+						// for this object cause it was matched by this product: the write role will 
+						// claim ownership of it.
 					}
+					if r.Mode == ModeWrite && (r.ProductID != pd.ProductID || r.DTAP != pd.DTAP) {
+						// So, another write role owned this object before, we need to check what user managed roles
+						// have been granted this other write role; they would lose ownership of the object if we
+						// would claim it; so we need to grant our write role to those user managed roles, if any
+						//
+						// We do this as a service. It is a normal thing that can happen when people rename a product
+						// in the YAML, i.e., change it's product id. Or when an object matching expression moves
+						// from one product to another.
+						for curOwner := range userManagedOwners(semantics.ProductDTAPID{ProductID: r.ProductID, DTAP: r.DTAP}) {
+							pd.userManagedOwnersOfObjects[curOwner] = struct{}{}
+						}
+					}
+					continue
 				}
 				// It's a user managed role, we add it
 				pd.userManagedOwnersOfObjects[aggObjAttr.Owner] = struct{}{}
 			}
 		}
+	}
+	return nil
+}
+
+func (pd *ProductDTAP) setGrantActionsFutureObjectsReadRole(ctx context.Context, cnf *Config, conn *sql.DB, productRoles map[ProductRole]struct{}) error {
+	// This function covers setting the todo and already done actions regarding privileges on future objects for the
+	// product read role. Objects are refreshed when a product is refreshed.
+	// It does not cover compute privileges, and it does not cover usage of database roles.
+	if _, ok := productRoles[pd.ReadRole]; !ok && cnf.DryRun {
+		return nil
+	}
+	for g, err := range QueryFutureGrantsToRoleFiltered(ctx, conn, pd.ReadRole.ID,	cnf.ObjectPrivileges, nil) {
+		if err != nil {
+			return err
+		}
+		switch g.GrantedIn {
+		case ObjTpDatabase:
+			switch g.GrantedOn {
+			case ObjTpSchema:
+				switch g.Privileges[0].Privilege {
+				case PrvUsage, PrvMonitor:
+					// Grupr does not normally assign these privileges, but sysadmins are encouraged to do so in case
+					// they want to grant privileges on objects in schemas directly to the read role that grupr does not (yet)
+					// manage. For that reason, we will leave these grants intact.
+					// Note though, that for read privileges, it would be more natural for sysadmins to assign them to database roles.
+					continue
+				}
+			}
+		}
+		// If we are still here, this grant will be a revoke candidate.
+		pd.toRevokeFutureObjects = append(pd.toRevokeFutureObjects, g)
+	}
+	return nil
+}
+
+func (pd *ProductDTAP) setGrantActionsObjectsReadRole(ctx context.Context, cnf *Config, conn *sql.DB,
+	grupinDisjointFromObject func(semantics.Ident, semantics.Ident, semantics.Ident) bool, productRoles map[ProductRole]struct{}) error {
+	// This function covers setting the todo and already done actions regarding privileges on objects for the product
+	// read role. Objects are refreshed when products are refreshed.
+	// It does not cover compute privileges, and it does not cover usage of database roles.
+	if _, ok := productRoles[pd.ReadRole]; !ok && cnf.DryRun {
+		return nil
+	}
+	for g, err := range QueryGrantsToRoleFiltered(ctx, cnf, conn, pd.ReadRole.ID, cnf.ObjectPrivileges, nil) {
+		if err != nil {
+			return err
+		}
+		switch pc := g.Privileges[0]; pc.Privilege {
+		case PrvOwnership:
+			if grupinDisjointFromObject(g.Database, g.Schema, g.Object) {
+				// There will be no other product claiming ownership of this object, we need to
+				// transfer its ownership to a role that is not managed by grupr.
+				// Note that when we refreshed, toTransferOwnership was reset to an empty slice
+				pd.toTransferOwnership = append(pd.toTransferOwnership, g)
+			}
+			continue // There is no revoking ownersip, so, continue either way
+		case PrvUsage, PrvMonitor:
+			// Grupr does not normally assign these privileges, but sysadmins are encouraged to do so in case
+			// they want to grant privileges on objects in schemas to the write role that grupr does not (yet)
+			// manage. For that reason, we will leave these grants intact.
+			continue
+		}
+		// If we are still here, this grant is a candidate for being revoked
+		pd.toRevokeObjects = append(pd.toRevokeObjects, g)
 	}
 	return nil
 }
@@ -350,18 +272,18 @@ func (pd *ProductDTAP) grant_(ctx context.Context, semCnf *semantics.Config, cnf
 
 	// Write grants go first, so that we do not have to copy all the read privileges we're about to set when granting ownership.
 	// As with read grants, future grants go first
-	if err := pd.setFutureGrantsToWriteRole(ctx, cnf, conn, productRoles); err != nil {
+	if err := pd.setGrantActionsFutureObjectsWriteRole(ctx, cnf, conn, productRoles); err != nil {
 		return err
 	}
-	if err := DoFutureGrants(ctx, cnf, conn, pd.getToDoFutureGrantsToWriteRole()); err != nil {
+	if err := DoFutureGrants(ctx, cnf, conn, pd.getTodoGrantsFutureObjectsWriteRole()); err != nil {
 		return err
 	}
 
 	// Now, regular grants to the write role
-	if err := pd.setGrantsToWriteRole(ctx, cnf, conn, grupinDisjointFromObject, productRoles); err != nil {
+	if err := pd.setGrantActionsObjectsWriteRole(ctx, cnf, conn, grupinDisjointFromObject, productRoles); err != nil {
 		return err
 	}
-	if err := DoGrants(ctx, cnf, conn, pd.getToDoGrantsToWriteRole()); err != nil {
+	if err := DoGrants(ctx, cnf, conn, pd.getToDoGrantsObjectsWriteRole()); err != nil {
 		return err
 	}
 	// We do ownership separately; we don't do them in batches, cause they can take longer due to copying outbound grants;
@@ -386,8 +308,10 @@ func (pd *ProductDTAP) grant_(ctx context.Context, semCnf *semantics.Config, cnf
 	if err := DoGrantsIndividually(ctx, cnf, conn, pd.getToDoOwnershipGrants()); err != nil {
 		return err
 	}
+	// At this point, granting of object privileges to the write role has been taken care of
 
-	// Future grants next, so that as quickly as possible newly created objects will have correct privileges granted
+	// Next, manage read privileges: we assign those to database roles.
+	// Future grants first, so that as quickly as possible newly created objects will have correct privileges granted
 	if err := pd.Interface.setFutureGrants(ctx, semCnf, cnf, conn, pd.ProductID, pd.DTAP, "", c); err != nil {
 		return err
 	}
@@ -396,7 +320,7 @@ func (pd *ProductDTAP) grant_(ctx context.Context, semCnf *semantics.Config, cnf
 			return err
 		}
 	}
-	if err := DoFutureGrants(ctx, cnf, conn, pd.getToDoFutureGrants()); err != nil {
+	if err := DoFutureGrants(ctx, cnf, conn, pd.getToDoFutureGrantsToDBRoles()); err != nil {
 		return err
 	}
 
@@ -409,7 +333,18 @@ func (pd *ProductDTAP) grant_(ctx context.Context, semCnf *semantics.Config, cnf
 			return err
 		}
 	}
-	if err := DoGrants(ctx, cnf, conn, pd.getToDoGrants()); err != nil {
+	if err := DoGrants(ctx, cnf, conn, pd.getToDoGrantsToDBRoles()); err != nil {
+		return err
+	}
+
+	// Finally, let's query the product read role for any spurious object privileges sysadmins
+	// may have granted it: privileges in scope for grupr, but, granted to the wrong role.
+	if err := pd.setGrantActionsFutureObjectsReadRole(ctx, cnf, conn, productRoles); err != nil {
+		return err
+	}
+
+	// Now, regular grants 
+	if err := pd.setGrantActionsObjectsReadRole(ctx, cnf, conn, grupinDisjointFromObject, productRoles); err != nil {
 		return err
 	}
 
@@ -417,7 +352,7 @@ func (pd *ProductDTAP) grant_(ctx context.Context, semCnf *semantics.Config, cnf
 }
 
 func (pd *ProductDTAP) revoke_(ctx context.Context, cnf *Config, conn *sql.DB) error {
-	// We first revoke write privileges, to stop the wrong roles from creating objects asap
+	// We first revoke privileges from product roles, to stop the wrong roles from creating objects asap
 	// As with read privileges, we start with future privileges
 	if err := DoFutureRevokes(ctx, cnf, conn, slices.Values(pd.toRevokeFutureObjects)); err != nil {
 		return err
@@ -456,19 +391,19 @@ func (pd *ProductDTAP) revoke_(ctx context.Context, cnf *Config, conn *sql.DB) e
 		log.Printf("WARN: multiple historic owners of objects that no longer should be owned by product '%s', dtap '%s', keeping ownership", pd.ProductID, pd.DTAP)
 	}
 
-	// Next, revoke read privileges
+	// Next, revoke read privileges from database roles
 	// Future grants are revoked first, in case objects are being concurrently created, at least those
 	// object will stop receiving incorrect grants first.
-	if err := DoFutureRevokes(ctx, cnf, conn, pd.getToDoFutureRevokes()); err != nil {
+	if err := DoFutureRevokes(ctx, cnf, conn, pd.getToDoFutureRevokesFromDBRoles()); err != nil {
 		return err
 	}
-	if err := DoRevokes(ctx, cnf, conn, pd.getToDoRevokes()); err != nil {
+	if err := DoRevokes(ctx, cnf, conn, pd.getToDoRevokesFromDBRoles()); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (pd *ProductDTAP) getToDoFutureGrantsToWriteRole() iter.Seq[FutureGrant] {
+func (pd *ProductDTAP) getTodoGrantsFutureObjectsWriteRole() iter.Seq[FutureGrant] {
 	return func(yield func(FutureGrant) bool) {
 		for db, dbObjs := range pd.Interface.aggAccountObjects.DBs {
 			if dbObjs.MatchAllSchemas {
@@ -498,7 +433,7 @@ func (pd *ProductDTAP) getToDoFutureGrantsToWriteRole() iter.Seq[FutureGrant] {
 	}
 }
 
-func (pd *ProductDTAP) getToDoGrantsToWriteRole() iter.Seq[Grant] {
+func (pd *ProductDTAP) getToDoGrantsObjectsWriteRole() iter.Seq[Grant] {
 	return func(yield func(Grant) bool) {
 		for db, dbObjs := range pd.Interface.aggAccountObjects.DBs {
 			for schema, schemaObjs := range dbObjs.Schemas {
@@ -570,7 +505,7 @@ func (pd *ProductDTAP) getToDoOwnershipGrants() iter.Seq[Grant] {
 	}
 }
 
-func (pd *ProductDTAP) getToDoFutureGrants() iter.Seq[FutureGrant] {
+func (pd *ProductDTAP) getToDoFutureGrantsToDBRoles() iter.Seq[FutureGrant] {
 	return func(yield func(FutureGrant) bool) {
 		if !pd.Interface.pushToDoFutureGrants(yield) {
 			return
@@ -583,7 +518,7 @@ func (pd *ProductDTAP) getToDoFutureGrants() iter.Seq[FutureGrant] {
 	}
 }
 
-func (pd *ProductDTAP) getToDoGrants() iter.Seq[Grant] {
+func (pd *ProductDTAP) getToDoGrantsToDBRoles() iter.Seq[Grant] {
 	return func(yield func(Grant) bool) {
 		if !pd.Interface.pushToDoGrants(yield) {
 			return
@@ -607,7 +542,7 @@ func (pd *ProductDTAP) getTransferOwnershipGrants(newOwner semantics.Ident) iter
 	}
 }
 
-func (pd *ProductDTAP) getToDoFutureRevokes() iter.Seq[FutureGrant] {
+func (pd *ProductDTAP) getToDoFutureRevokesFromDBRoles() iter.Seq[FutureGrant] {
 	return func(yield func(FutureGrant) bool) {
 		if !pd.Interface.pushToDoFutureRevokes(yield) {
 			return
@@ -620,7 +555,7 @@ func (pd *ProductDTAP) getToDoFutureRevokes() iter.Seq[FutureGrant] {
 	}
 }
 
-func (pd *ProductDTAP) getToDoRevokes() iter.Seq[Grant] {
+func (pd *ProductDTAP) getToDoRevokesFromDBRoles() iter.Seq[Grant] {
 	return func(yield func(Grant) bool) {
 		if !pd.Interface.pushToDoRevokes(yield) {
 			return

--- a/internal/snowflake/product_dtap__objects.go
+++ b/internal/snowflake/product_dtap__objects.go
@@ -152,7 +152,7 @@ func (pd *ProductDTAP) setUserManagedOwnersOfObjects(semCnf *semantics.Config, c
 					if err != nil {
 						// In this case, it would have to be a database role, or else other roles
 						// exist sharing the grupr prefix, this would be a good reason to crash
-						if _, err = newDatabaseRoleFromString(semCnf, db, aggObjAttr.Owner); err != nil {
+						if _, err = newDatabaseRoleFromIdent(semCnf, db, aggObjAttr.Owner); err != nil {
 							return err
 						}
 						// Okay, so it was a database role that owned the object. Not something sysadmins
@@ -196,7 +196,7 @@ func (pd *ProductDTAP) grant_(ctx context.Context, semCnf *semantics.Config, cnf
 	if err := pd.setGrantActionsFutureObjectsWriteRole(ctx, cnf, conn, productRoles); err != nil {
 		return err
 	}
-	if err := DoFutureGrants(ctx, cnf, conn, pd.getTodoGrantsFutureObjectsWriteRole()); err != nil {
+	if err := DoFutureGrants(ctx, cnf, conn, pd.getTodoGrantsFutureObjectsWriteRole(cnf.ManagedObjTypes)); err != nil {
 		return err
 	}
 
@@ -204,7 +204,7 @@ func (pd *ProductDTAP) grant_(ctx context.Context, semCnf *semantics.Config, cnf
 	if err := pd.setGrantActionsObjectsWriteRole(ctx, cnf, conn, grupinDisjointFromObject, productRoles); err != nil {
 		return err
 	}
-	if err := DoGrants(ctx, cnf, conn, pd.getToDoGrantsObjectsWriteRole()); err != nil {
+	if err := DoGrants(ctx, cnf, conn, pd.getToDoGrantsObjectsWriteRole(cnf.ManagedObjTypes)); err != nil {
 		return err
 	}
 	// We do ownership separately; we don't do them in batches, cause they can take longer due to copying outbound grants;
@@ -401,7 +401,7 @@ func (pd *ProductDTAP) getToDoOwnershipGrants() iter.Seq[Grant] {
 			for schema, schemaObjs := range dbObjs.Schemas {
 				for obj, objAttr := range schemaObjs.Objects {
 					if !objAttr.isOwnedByProductWriteRole {
-						ot = objAttr.ObjectType
+						ot := objAttr.ObjectType
 						if ot == ObjTpHybridTable {
 							// In snowflake GRANT <privileges> ..., HYBRID TABLE is not a recongnized object type
 							ot = ObjTpTable

--- a/internal/snowflake/product_dtap__warehouses.go
+++ b/internal/snowflake/product_dtap__warehouses.go
@@ -15,9 +15,9 @@ In product_dtap__objects.go, we have ProductDTAP methods that deal with (privile
 func (pd *ProductDTAP) addWarehouse(m Mode, id semantics.Ident) {
 	switch m {
 	case ModeRead:
-		pd.ReadWarehouses[id] = [2]bool{}
+		pd.ReadWarehouses[id] = [3]bool{}
 	case ModeWrite:
-		pd.WriteWarehouses[id] = [2]bool{}
+		pd.WriteWarehouses[id] = [3]bool{}
 	}
 }
 
@@ -49,16 +49,7 @@ func (pd *ProductDTAP) setWarehouseGrants(ctx context.Context, cnf *Config, conn
 		if _, ok := productRoles[pr]; !ok && cnf.DryRun {
 			continue
 		}
-		for g, err := range QueryGrantsToRoleFiltered(ctx, cnf, conn, pr.ID, map[GrantTemplate]struct{}{
-			GrantTemplate{
-				PrivilegeComplete: PrivilegeComplete{Privilege: PrvUsage},
-				GrantedOn:         ObjTpWarehouse,
-			}: {},
-			GrantTemplate{
-				PrivilegeComplete: PrivilegeComplete{Privilege: PrvOperate},
-				GrantedOn:         ObjTpWarehouse,
-			}: {},
-		}, nil) {
+		for g, err := range QueryGrantsToRoleFiltered(ctx, cnf, conn, pr.ID, cnf.ComputePrivileges, nil) {
 			if err != nil {
 				return err
 			}
@@ -87,6 +78,9 @@ func (pd *ProductDTAP) getToDoWarehouseGrants() iter.Seq[Grant] {
 				prvs := []PrivilegeComplete{}
 				if !hasFlagPrivilegeWarehouse(flags, PrvUsage) {
 					prvs = append(prvs, PrivilegeComplete{Privilege: PrvUsage})
+				}
+				if !hasFlagPrivilegeWarehouse(flags, PrvMonitor) {
+					prvs = append(prvs, PrivilegeComplete{Privilege: PrvMonitor})
 				}
 				if !hasFlagPrivilegeWarehouse(flags, PrvOperate) {
 					prvs = append(prvs, PrivilegeComplete{Privilege: PrvOperate})

--- a/internal/snowflake/product_role.go
+++ b/internal/snowflake/product_role.go
@@ -29,7 +29,7 @@ func newProductRole(semCnf *semantics.Config, productID string, dtap string, mod
 	}
 }
 
-func newProductRoleFromString(semCnf *semantics.Config, role semantics.Ident) (ProductRole, error) {
+func newProductRoleFromIdent(semCnf *semantics.Config, role semantics.Ident) (ProductRole, error) {
 	r := ProductRole{ID: role}
 	roleStr := string(role)
 	if !strings.HasPrefix(roleStr, string(semCnf.Prefix)) {

--- a/internal/snowflake/product_role.go
+++ b/internal/snowflake/product_role.go
@@ -61,7 +61,11 @@ func (r ProductRole) Create(ctx context.Context, cnf *Config, conn *sql.DB) erro
 }
 
 func (r ProductRole) hasUnmanagedPrivileges(ctx context.Context, cnf *Config, conn *sql.DB) (bool, error) {
-	for _, err := range QueryGrantsToRoleFilteredLimit(ctx, cnf, conn, r.ID, nil, cnf.ProductRolePrivileges[r.Mode], 1) {
+	// Because we have zombie product dtaps, we should have already revoked all managed grants,
+	// and made attempts to transfer ownership. So if there is any grant left, no matter what it
+	// is, we should not drop the role. Either it is an unmanaged grant that sysadmins added,
+	// or it is ownership on an object that grupr did not yet figure out who to transfer it to.
+	for _, err := range QueryGrantsToRoleFilteredLimit(ctx, cnf, conn, r.ID, nil, nil, 1) {
 		if err != nil {
 			return true, err
 		}

--- a/internal/snowflake/product_role.go
+++ b/internal/snowflake/product_role.go
@@ -60,7 +60,7 @@ func (r ProductRole) Create(ctx context.Context, cnf *Config, conn *sql.DB) erro
 	return nil
 }
 
-func (r ProductRole) hasUnmanagedPrivileges(ctx context.Context, cnf *Config, conn *sql.DB) (bool, error) {
+func (r ProductRole) hasPrivileges(ctx context.Context, cnf *Config, conn *sql.DB) (bool, error) {
 	// Because we have zombie product dtaps, we should have already revoked all managed grants,
 	// and made attempts to transfer ownership. So if there is any grant left, no matter what it
 	// is, we should not drop the role. Either it is an unmanaged grant that sysadmins added,
@@ -75,10 +75,10 @@ func (r ProductRole) hasUnmanagedPrivileges(ctx context.Context, cnf *Config, co
 }
 
 func (r ProductRole) Drop(ctx context.Context, cnf *Config, conn *sql.DB) error {
-	if has, err := r.hasUnmanagedPrivileges(ctx, cnf, conn); err != nil {
+	if has, err := r.hasPrivileges(ctx, cnf, conn); err != nil {
 		return err
 	} else if has {
-		log.Printf("role %v has privileges not managed by Grupr, skipping dropping\n", r)
+		log.Printf("role %v still has privileges, skipping dropping\n", r)
 		return nil
 	}
 	return runSQL(ctx, cnf, conn, `DROP ROLE IF EXISTS IDENTIFIER(?)`, r.String())

--- a/internal/snowflake/schema_cache.go
+++ b/internal/snowflake/schema_cache.go
@@ -14,10 +14,10 @@ type schemaCache struct {
 	objects map[semantics.Ident]ObjAttr // nil: never requested; empty: none present;
 }
 
-func (c *schemaCache) refreshObjects(ctx context.Context, conn *sql.DB, db semantics.Ident, schema semantics.Ident) error {
+func (c *schemaCache) refreshObjects(ctx context.Context, conn *sql.DB, db semantics.Ident, schema semantics.Ident, map[ObjType]bool mots) error {
 	// intended to be called from accountCache.match and friends, which will acquire locks on the appropriate mutexes
 	c.objects = map[semantics.Ident]ObjAttr{} // overwrite if it had a value
-	for obj, err := range QueryObjs(ctx, conn, db, schema) {
+	for obj, err := range QueryObjs(ctx, conn, db, schema, mots) {
 		if err != nil {
 			return err
 		}

--- a/internal/snowflake/schema_cache.go
+++ b/internal/snowflake/schema_cache.go
@@ -14,7 +14,7 @@ type schemaCache struct {
 	objects map[semantics.Ident]ObjAttr // nil: never requested; empty: none present;
 }
 
-func (c *schemaCache) refreshObjects(ctx context.Context, conn *sql.DB, db semantics.Ident, schema semantics.Ident, map[ObjType]bool mots) error {
+func (c *schemaCache) refreshObjects(ctx context.Context, conn *sql.DB, db semantics.Ident, schema semantics.Ident, mots map[ObjType]bool) error {
 	// intended to be called from accountCache.match and friends, which will acquire locks on the appropriate mutexes
 	c.objects = map[semantics.Ident]ObjAttr{} // overwrite if it had a value
 	for obj, err := range QueryObjs(ctx, conn, db, schema, mots) {

--- a/internal/snowflake/table_rec.go
+++ b/internal/snowflake/table_rec.go
@@ -11,19 +11,19 @@ import (
 )
 
 type tableRec struct {
-	name semantics.Ident
-	owner semantics.Ident
-	is_external string
+	name            semantics.Ident
+	owner           semantics.Ident
+	is_external     string
 	owner_role_type string
-	is_event string
-	is_hybrid string
-	is_iceberg string
-	is_dynamic string
-	is_immutable string // should always be N anyway, since we filter out temporary tables, but, never mind, could change in the future.
-	is_interactive string
+	is_event        string
+	is_hybrid       string
+	is_iceberg      string
+	is_dynamic      string
+	is_immutable    string // should always be N anyway, since we filter out temporary tables, but, never mind, could change in the future.
+	is_interactive  string
 }
 
-func (r tableRec) getObjType(map[ObjType]bool mots) ObjType {
+func (r tableRec) getObjType(mots map[ObjType]bool) ObjType {
 	// First, exclude any object not owned by a role
 	// Fortunately, in Snowflake, until now OWNERSHIP and CREATE cannot be granted to users yet (May 2026)
 	// See: https://docs.snowflake.com/en/sql-reference/sql/grant-privilege-user
@@ -59,7 +59,7 @@ func queryTables(ctx context.Context, conn *sql.DB, db semantics.Ident, schema s
 	// If new types of tables are returned in the future, with flags like "is_new_type_X", "is_new_type_Y",
 	// grupr will treat it like a regular table. That means grupr may crash, for example, when it tries to
 	// grant SELECT ERROR TABLE, which, as of Apr 2026, is only applicable to normal tables.
-	// 
+	//
 	// Until Snowflake adds a flag "is_normal" to the output of the SHOW TABLES function (and friends like SHOW OBJECTS,
 	// SHOW VIEWS, etc, I see no easy way to prevent this problem, other than quickly fixing grupr each time Snowflake
 	// comes out with something new (again).

--- a/internal/snowflake/table_rec.go
+++ b/internal/snowflake/table_rec.go
@@ -86,7 +86,7 @@ SELECT
   , "is_interactive" AS is_interactive
 FROM $1
 WHERE
-    kind IN ('TABLE', 'TRANSIENT')
+    "kind" IN ('TABLE', 'TRANSIENT')
 AND owner_role_type = '%s'
 AND is_external = 'N'
 AND is_event = 'N'

--- a/internal/snowflake/table_rec.go
+++ b/internal/snowflake/table_rec.go
@@ -23,11 +23,10 @@ type tableRec struct {
 	is_interactive string
 }
 
-func (r tableRec) getObjType() ObjType {
+func (r tableRec) getObjType(map[ObjType]bool mots) ObjType {
 	// First, exclude any object not owned by a role
-	// TODO WIP think through the implication of ignoring objects that are owned by a user (can that happen?)
-	// For example, if we hold grants on objects like that, what will happen? In cases where such objects are matched /
-	// not matched in the YAML / matched in the YAML for a different product, etc?
+	// Fortunately, in Snowflake, until now OWNERSHIP and CREATE cannot be granted to users yet (May 2026)
+	// See: https://docs.snowflake.com/en/sql-reference/sql/grant-privilege-user
 	if ParseObjType(r.owner_role_type) != ObjTpRole {
 		return ObjTpOther
 	}

--- a/internal/snowflake/table_rec.go
+++ b/internal/snowflake/table_rec.go
@@ -114,7 +114,7 @@ FROM $1
 				if strings.Contains(err.Error(), "390201") { // ErrObjectNotExistOrAuthorized; this way of testing error code is used in errors_test in the gosnowflake repo
 					err = ErrObjectNotExistOrAuthorized
 				}
-				yield(Obj{}, err)
+				yield(tableRec{}, err)
 				return
 			}
 			defer rows.Close()

--- a/internal/snowflake/table_rec.go
+++ b/internal/snowflake/table_rec.go
@@ -25,6 +25,9 @@ type tableRec struct {
 
 func (r tableRec) getObjType() ObjType {
 	// First, exclude any object not owned by a role
+	// TODO WIP think through the implication of ignoring objects that are owned by a user (can that happen?)
+	// For example, if we hold grants on objects like that, what will happen? In cases where such objects are matched /
+	// not matched in the YAML / matched in the YAML for a different product, etc?
 	if ParseObjType(r.owner_role_type) != ObjTpRole {
 		return ObjTpOther
 	}

--- a/internal/snowflake/table_rec.go
+++ b/internal/snowflake/table_rec.go
@@ -1,0 +1,142 @@
+package snowflake
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"iter"
+	"strings"
+
+	"github.com/rwberendsen/grupr/internal/semantics"
+)
+
+type tableRec struct {
+	name semantics.Ident
+	owner semantics.Ident
+	is_external bool
+	owner_role_type string
+	is_event bool
+	is_hybrid bool
+	is_iceberg bool
+	is_dynamic bool
+	is_immutable bool
+	is_interactive bool
+}
+
+func (r tableRec) getObjType() ObjType {
+	if ParseObjType(r.owner_role_type) != ObjTpRole {
+		return ObjTpOther
+	}
+	if r.is_external || r.is_event || r.is_hybrid || r.is_iceberg || r.is_dynamic || r.is_immutable || r.is_interactive {
+		return ObjTpOther
+	}
+	return ObjTpTable
+}
+
+func queryTables(ctx context.Context, conn *sql.DB, db semantics.Ident, schema semantics.Ident) iter.Seq2[tableRec,
+	error] {
+	// The main problem with the SHOW TABLES function is that there is no flag "is_normal" for regular tables.
+	// If new types of tables are returned in the future, with flags like "is_new_type_X", "is_new_type_Y",
+	// grupr will treat it like a regular table. That means grupr may crash, for example, when it tries to
+	// grant SELECT ERROR TABLE, which, as of Apr 2026, is only applicable to normal tables.
+	// 
+	// Until Snowflake adds a flag "is_normal" to the output of the SHOW TABLES function (and friends like SHOW OBJECTS,
+	// SHOW VIEWS, etc, I see no easy way to prevent this problem, other than quickly fixing grupr each time Snowflake
+	// comes out with something new (again).
+	return func(yield func(tableRec, error) bool) {
+		// When there are more than 10K results, paginate.
+		// Because we apply filters, even if fewer results are returned, perhaps there are still more.
+		// For that reason, our last row has a count of the first query result
+		mayHaveMore := true
+		var fromClause string
+		limit := 10000
+		for mayHaveMore {
+			rows, err := conn.QueryContext(ctx, fmt.Sprintf(`SHOW TABLES IN SCHEMA IDENTIFIER($$%s.%s$$) LIMIT %d%s ->>
+SELECT
+    NULL AS n
+  , "name" AS name
+  , "owner" AS owner
+  , "is_external" AS is_external
+  , "owner_role_type" AS owner_role_type
+  , "is_event" AS is_event
+  , "is_hybrid" AS is_hybrid
+  , "is_iceberg" AS is_iceberg
+  , "is_dynamic" AS is_dynamic
+  , "is_immutable" AS is_immutable
+  , "is_interactive" AS is_interactive
+FROM $1
+WHERE
+    kind IN ('TABLE', 'TRANSIENT')
+AND owner_role_type = '%s'
+AND is_external = 'N'
+AND is_event = 'N'
+AND is_hybrid = 'N'
+AND is_iceberg = 'N'
+AND is_dynamic = 'N'
+AND is_immutable = 'N'
+AND is_interactive = 'N'
+UNION ALL
+SELECT
+    COUNT(*)
+  , '' AS name
+  , '' AS owner
+  , '' AS is_external
+  , '' AS owner_role_type
+  , '' AS is_event
+  , '' AS is_hybrid
+  , '' AS is_iceberg
+  , '' AS is_dynamic
+  , '' AS is_immutable
+  , '' AS is_interactive
+FROM $1
+`, db, schema, limit, fromClause, ObjTpRole.RecordString))
+			if err != nil {
+				if strings.Contains(err.Error(), "390201") { // ErrObjectNotExistOrAuthorized; this way of testing error code is used in errors_test in the gosnowflake repo
+					err = ErrObjectNotExistOrAuthorized
+				}
+				yield(Obj{}, err)
+				return
+			}
+			defer rows.Close()
+			var lastName semantics.Ident
+			for rows.Next() {
+				var n *int
+				var rec tableRec
+				if err = rows.Scan(
+					&n,
+					&rec.name,
+					&rec.owner,
+					&rec.is_external,
+					&rec.owner_role_type,
+					&rec.is_event,
+					&rec.is_hybrid,
+					&rec.is_iceberg,
+					&rec.is_dynamic,
+					&rec.is_immutable,
+					&rec.is_interactive,
+				); err != nil {
+					err = fmt.Errorf("queryTables: error scanning row: %w", err)
+					yield(rec, err)
+					return
+				}
+				if n != nil { // this is the last row holding the count
+					if *n < limit {
+						mayHaveMore = false
+					} else {
+						fromClause = fmt.Sprintf(" FROM '%s'", string(lastName))
+					}
+					continue
+				}
+				if !yield(rec, nil) {
+					return
+				}
+				lastName = rec.name
+			}
+			if err = rows.Err(); err != nil {
+				err = fmt.Errorf("queryTables: error after looping over results: %w", err)
+				yield(tableRec{}, err)
+				return
+			}
+		}
+	}
+}

--- a/internal/snowflake/table_rec.go
+++ b/internal/snowflake/table_rec.go
@@ -19,24 +19,36 @@ type tableRec struct {
 	is_hybrid string
 	is_iceberg string
 	is_dynamic string
-	is_immutable string
+	is_immutable string // should always be N anyway, since we filter out temporary tables, but, never mind, could change in the future.
 	is_interactive string
 }
 
 func (r tableRec) getObjType() ObjType {
+	// First, exclude any object not owned by a role
 	if ParseObjType(r.owner_role_type) != ObjTpRole {
 		return ObjTpOther
 	}
-	if r.is_external == "Y" || 
-		r.is_event == "Y" ||
-		r.is_hybrid == "Y" ||
-		r.is_iceberg == "Y" ||
-		r.is_dynamic == "Y" ||
-		r.is_immutable == "Y" ||
-		r.is_interactive == "Y" {
-		return ObjTpOther
+	// Now, start accepting objects of types we manage
+	if r.is_external == "N" &&
+		r.is_hybrid == "N" &&
+		r.is_event == "N" &&
+		r.is_iceberg == "N" &&
+		r.is_dynamic == "N" &&
+		r.is_immutable == "N" &&
+		r.is_interactive == "N" {
+		return ObjTpTable
 	}
-	return ObjTpTable
+	if r.is_external == "N" &&
+		r.is_hybrid == "Y" &&
+		r.is_event == "N" &&
+		r.is_iceberg == "N" &&
+		r.is_dynamic == "N" &&
+		r.is_immutable == "N" &&
+		r.is_interactive == "N" {
+		return ObjTpHybridTable
+	}
+	// Else, return ObjTpOther, meaning this object type is not managed by grupr
+	return ObjTpOther
 }
 
 func queryTables(ctx context.Context, conn *sql.DB, db semantics.Ident, schema semantics.Ident) iter.Seq2[tableRec,

--- a/internal/snowflake/table_rec.go
+++ b/internal/snowflake/table_rec.go
@@ -13,21 +13,27 @@ import (
 type tableRec struct {
 	name semantics.Ident
 	owner semantics.Ident
-	is_external bool
+	is_external string
 	owner_role_type string
-	is_event bool
-	is_hybrid bool
-	is_iceberg bool
-	is_dynamic bool
-	is_immutable bool
-	is_interactive bool
+	is_event string
+	is_hybrid string
+	is_iceberg string
+	is_dynamic string
+	is_immutable string
+	is_interactive string
 }
 
 func (r tableRec) getObjType() ObjType {
 	if ParseObjType(r.owner_role_type) != ObjTpRole {
 		return ObjTpOther
 	}
-	if r.is_external || r.is_event || r.is_hybrid || r.is_iceberg || r.is_dynamic || r.is_immutable || r.is_interactive {
+	if r.is_external == "Y" || 
+		r.is_event == "Y" ||
+		r.is_hybrid == "Y" ||
+		r.is_iceberg == "Y" ||
+		r.is_dynamic == "Y" ||
+		r.is_immutable == "Y" ||
+		r.is_interactive == "Y" {
 		return ObjTpOther
 	}
 	return ObjTpTable
@@ -89,7 +95,7 @@ SELECT
   , '' AS is_immutable
   , '' AS is_interactive
 FROM $1
-`, db, schema, limit, fromClause, ObjTpRole.RecordString))
+`, db, schema, limit, fromClause, ObjTpRole.RecordString()))
 			if err != nil {
 				if strings.Contains(err.Error(), "390201") { // ErrObjectNotExistOrAuthorized; this way of testing error code is used in errors_test in the gosnowflake repo
 					err = ErrObjectNotExistOrAuthorized

--- a/internal/snowflake/view_rec.go
+++ b/internal/snowflake/view_rec.go
@@ -22,6 +22,7 @@ func (r viewRec) getObjType() ObjType {
 	if ParseObjType(r.owner_role_type) != ObjTpRole {
 		return ObjTpOther
 	}
+	// TODO WIP: recognize Materialize views as well
 	if r.is_secure || r.is_materialized {
 		return ObjTpOther
 	}

--- a/internal/snowflake/view_rec.go
+++ b/internal/snowflake/view_rec.go
@@ -12,27 +12,30 @@ import (
 
 type viewRec struct {
 	name semantics.Ident
-	kind string
 	owner semantics.Ident
-	is_external bool
+	is_secure bool
+	is_materialized bool
 	owner_role_type ObjType
-	is_event bool
-	is_hybrid bool
-	is_iceberg bool
-	is_dynamic bool
-	is_immutable bool
-	is_interactive bool
 }
 
-func queryTables(ctx context.Context, conn *sql.DB, db semantics.Ident, schema semantics.Ident) iter.Seq2[tableRec,
-	error] {
+func (r viewRec) getObjType() ObjType {
+	if ParseObjType(r.owner_role_type) != ObjTpRole {
+		return ObjTpOther
+	}
+	if r.is_secure || r.is_materialized {
+		return ObjTpOther
+	}
+	return ObjTpView
+}
+
+func queryViews(ctx context.Context, conn *sql.DB, db semantics.Ident, schema semantics.Ident) iter.Seq2[viewRec, error] {
 	// The main problem with the SHOW VIEWS function is that there is no flag "is_normal" for regular views.
 	// If new types of views are returned in the future, with flags like "is_new_type_X", "is_new_type_Y",
 	// grupr will treat it like a regular view.
 	// Until Snowflake adds a flag "is_normal" to the output of the SHOW VIEWS function (and friends like SHOW OBJECTS,
 	// SHOW TABLES, etc, I see no easy way to prevent this problem, other than quickly fixing grupr each time Snowflake
 	// comes out with something new (again).
-	return func(yield func(tableRec, error) bool) {
+	return func(yield func(viewRec, error) bool) {
 		// When there are more than 10K results, paginate.
 		// Because we apply filters, even if fewer results are returned, perhaps there are still more.
 		// For that reason, our last row has a count of the first query result
@@ -40,47 +43,29 @@ func queryTables(ctx context.Context, conn *sql.DB, db semantics.Ident, schema s
 		var fromClause string
 		limit := 10000
 		for mayHaveMore {
-			rows, err := conn.QueryContext(ctx, fmt.Sprintf(`SHOW TABLES IN SCHEMA IDENTIFIER($$%s.%s$$) LIMIT %d%s ->>
+			rows, err := conn.QueryContext(ctx, fmt.Sprintf(`SHOW VIEWS IN SCHEMA IDENTIFIER($$%s.%s$$) LIMIT %d%s ->>
 SELECT
     NULL AS n
   , "name" AS name
-  , "kind" AS kind
   , "owner" AS owner
-  , "is_external" AS is_external
+  , "is_secure" AS is_secure
+  , "is_materialized" AS is_materialized
   , "owner_role_type" AS owner_role_type
-  , "is_event" AS is_event
-  , "is_hybrid" AS is_hybrid
-  , "is_iceberg" AS is_iceberg
-  , "is_dynamic" AS is_dynamic
-  , "is_immutable" AS is_immutable
-  , "is_interactive" AS is_interactive
 FROM $1
 WHERE
-    kind IN ('TABLE', 'TRANSIENT')
-AND owner_role_type = 'ROLE'
-AND is_external = 'N'
-AND is_event = 'N'
-AND is_hybrid = 'N'
-AND is_iceberg = 'N'
-AND is_dynamic = 'N'
-AND is_immutable = 'N'
-AND is_interactive = 'N'
+    owner_role_type = '%s'
+AND NOT is_secure
+AND NOT is_materialized
 UNION ALL
 SELECT
     COUNT(*)
   , '' AS name
-  , '' AS kind
   , '' AS owner
-  , '' AS is_external
+  , false AS is_secure
+  , false AS is_materialized
   , '' AS owner_role_type
-  , '' AS is_event
-  , '' AS is_hybrid
-  , '' AS is_iceberg
-  , '' AS is_dynamic
-  , '' AS is_immutable
-  , '' AS is_interactive
 FROM $1
-`, db, schema, limit, fromClause))
+`, db, schema, limit, fromClause, ObjTpRole.RecordString()))
 			if err != nil {
 				if strings.Contains(err.Error(), "390201") { // ErrObjectNotExistOrAuthorized; this way of testing error code is used in errors_test in the gosnowflake repo
 					err = ErrObjectNotExistOrAuthorized
@@ -92,22 +77,16 @@ FROM $1
 			var lastName semantics.Ident
 			for rows.Next() {
 				var n *int
-				var rec tableRec
+				var rec viewRec
 				if err = rows.Scan(
 					&n,
 					&rec.name,
-					&rec.kind,
 					&rec.owner,
-					&rec.is_external,
+					&rec.is_secure,
+					&rec.is_materialized,
 					&rec.owner_role_type,
-					&rec.is_event,
-					&rec.is_hybrid,
-					&rec.is_iceberg,
-					&rec.is_dynamic,
-					&rec.is_immutable,
-					&rec.is_interactive,
 				); err != nil {
-					err = fmt.Errorf("queryTables: error scanning row: %w", err)
+					err = fmt.Errorf("queryViews: error scanning row: %w", err)
 					yield(rec, err)
 					return
 				}
@@ -125,8 +104,8 @@ FROM $1
 				lastName = rec.name
 			}
 			if err = rows.Err(); err != nil {
-				err = fmt.Errorf("queryTables: error after looping over results: %w", err)
-				yield(tableRec{}, err)
+				err = fmt.Errorf("queryViews: error after looping over results: %w", err)
+				yield(viewRec{}, err)
 				return
 			}
 		}

--- a/internal/snowflake/view_rec.go
+++ b/internal/snowflake/view_rec.go
@@ -1,0 +1,134 @@
+package snowflake
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"iter"
+	"strings"
+
+	"github.com/rwberendsen/grupr/internal/semantics"
+)
+
+type viewRec struct {
+	name semantics.Ident
+	kind string
+	owner semantics.Ident
+	is_external bool
+	owner_role_type ObjType
+	is_event bool
+	is_hybrid bool
+	is_iceberg bool
+	is_dynamic bool
+	is_immutable bool
+	is_interactive bool
+}
+
+func queryTables(ctx context.Context, conn *sql.DB, db semantics.Ident, schema semantics.Ident) iter.Seq2[tableRec,
+	error] {
+	// The main problem with the SHOW VIEWS function is that there is no flag "is_normal" for regular views.
+	// If new types of views are returned in the future, with flags like "is_new_type_X", "is_new_type_Y",
+	// grupr will treat it like a regular view.
+	// Until Snowflake adds a flag "is_normal" to the output of the SHOW VIEWS function (and friends like SHOW OBJECTS,
+	// SHOW TABLES, etc, I see no easy way to prevent this problem, other than quickly fixing grupr each time Snowflake
+	// comes out with something new (again).
+	return func(yield func(tableRec, error) bool) {
+		// When there are more than 10K results, paginate.
+		// Because we apply filters, even if fewer results are returned, perhaps there are still more.
+		// For that reason, our last row has a count of the first query result
+		mayHaveMore := true
+		var fromClause string
+		limit := 10000
+		for mayHaveMore {
+			rows, err := conn.QueryContext(ctx, fmt.Sprintf(`SHOW TABLES IN SCHEMA IDENTIFIER($$%s.%s$$) LIMIT %d%s ->>
+SELECT
+    NULL AS n
+  , "name" AS name
+  , "kind" AS kind
+  , "owner" AS owner
+  , "is_external" AS is_external
+  , "owner_role_type" AS owner_role_type
+  , "is_event" AS is_event
+  , "is_hybrid" AS is_hybrid
+  , "is_iceberg" AS is_iceberg
+  , "is_dynamic" AS is_dynamic
+  , "is_immutable" AS is_immutable
+  , "is_interactive" AS is_interactive
+FROM $1
+WHERE
+    kind IN ('TABLE', 'TRANSIENT')
+AND owner_role_type = 'ROLE'
+AND is_external = 'N'
+AND is_event = 'N'
+AND is_hybrid = 'N'
+AND is_iceberg = 'N'
+AND is_dynamic = 'N'
+AND is_immutable = 'N'
+AND is_interactive = 'N'
+UNION ALL
+SELECT
+    COUNT(*)
+  , '' AS name
+  , '' AS kind
+  , '' AS owner
+  , '' AS is_external
+  , '' AS owner_role_type
+  , '' AS is_event
+  , '' AS is_hybrid
+  , '' AS is_iceberg
+  , '' AS is_dynamic
+  , '' AS is_immutable
+  , '' AS is_interactive
+FROM $1
+`, db, schema, limit, fromClause))
+			if err != nil {
+				if strings.Contains(err.Error(), "390201") { // ErrObjectNotExistOrAuthorized; this way of testing error code is used in errors_test in the gosnowflake repo
+					err = ErrObjectNotExistOrAuthorized
+				}
+				yield(Obj{}, err)
+				return
+			}
+			defer rows.Close()
+			var lastName semantics.Ident
+			for rows.Next() {
+				var n *int
+				var rec tableRec
+				if err = rows.Scan(
+					&n,
+					&rec.name,
+					&rec.kind,
+					&rec.owner,
+					&rec.is_external,
+					&rec.owner_role_type,
+					&rec.is_event,
+					&rec.is_hybrid,
+					&rec.is_iceberg,
+					&rec.is_dynamic,
+					&rec.is_immutable,
+					&rec.is_interactive,
+				); err != nil {
+					err = fmt.Errorf("queryTables: error scanning row: %w", err)
+					yield(rec, err)
+					return
+				}
+				if n != nil { // this is the last row holding the count
+					if *n < limit {
+						mayHaveMore = false
+					} else {
+						fromClause = fmt.Sprintf(" FROM '%s'", string(lastName))
+					}
+					continue
+				}
+				if !yield(rec, nil) {
+					return
+				}
+				lastName = rec.name
+			}
+			if err = rows.Err(); err != nil {
+				err = fmt.Errorf("queryTables: error after looping over results: %w", err)
+				yield(tableRec{}, err)
+				return
+			}
+		}
+	}
+}

--- a/internal/snowflake/view_rec.go
+++ b/internal/snowflake/view_rec.go
@@ -11,14 +11,14 @@ import (
 )
 
 type viewRec struct {
-	name semantics.Ident
-	owner semantics.Ident
-	is_secure bool
+	name            semantics.Ident
+	owner           semantics.Ident
+	is_secure       bool
 	is_materialized bool
 	owner_role_type ObjType
 }
 
-func (r viewRec) getObjType(maps[ObjType]bool mots) ObjType {
+func (r viewRec) getObjType(mots map[ObjType]bool) ObjType {
 	// First, exclude any object not owned by a role
 	// Fortunately, in Snowflake, until now OWNERSHIP and CREATE cannot be granted to users yet (May 2026)
 	// See: https://docs.snowflake.com/en/sql-reference/sql/grant-privilege-user

--- a/internal/snowflake/view_rec.go
+++ b/internal/snowflake/view_rec.go
@@ -18,15 +18,24 @@ type viewRec struct {
 	owner_role_type ObjType
 }
 
-func (r viewRec) getObjType() ObjType {
+func (r viewRec) getObjType(maps[ObjType]bool mots) ObjType {
+	// First, exclude any object not owned by a role
+	// Fortunately, in Snowflake, until now OWNERSHIP and CREATE cannot be granted to users yet (May 2026)
+	// See: https://docs.snowflake.com/en/sql-reference/sql/grant-privilege-user
+	//
+	// mots stands for (Managed Object Type)S
 	if ParseObjType(r.owner_role_type) != ObjTpRole {
 		return ObjTpOther
 	}
-	// TODO WIP: recognize Materialize views as well
-	if r.is_secure || r.is_materialized {
-		return ObjTpOther
+	if !r.is_materialized {
+		return ObjTpView
 	}
-	return ObjTpView
+	if mots[ObjTpMaterializedView] {
+		if r.is_materialized {
+			return ObjTpMaterializedView
+		}
+	}
+	return ObjTpOther
 }
 
 func queryViews(ctx context.Context, conn *sql.DB, db semantics.Ident, schema semantics.Ident) iter.Seq2[viewRec, error] {

--- a/internal/snowflake/view_rec.go
+++ b/internal/snowflake/view_rec.go
@@ -15,7 +15,7 @@ type viewRec struct {
 	owner           semantics.Ident
 	is_secure       bool
 	is_materialized bool
-	owner_role_type ObjType
+	owner_role_type string
 }
 
 func (r viewRec) getObjType(mots map[ObjType]bool) ObjType {
@@ -80,7 +80,7 @@ FROM $1
 				if strings.Contains(err.Error(), "390201") { // ErrObjectNotExistOrAuthorized; this way of testing error code is used in errors_test in the gosnowflake repo
 					err = ErrObjectNotExistOrAuthorized
 				}
-				yield(Obj{}, err)
+				yield(viewRec{}, err)
 				return
 			}
 			defer rows.Close()


### PR DESCRIPTION
More clearly defining what are managed grants in grupr for each grupr-managed role

- Update docs in Readme
- Add monitor grant on databases and schemas
- Add monitor grant on warehouses
- Adding support for hybrid tables
- Correct logic to work correctly for hybrid tables, which are modeled as regular tables in SHOW GRANTS output and in GRANT statements
- Adding support for materialized views
- Adding opt-in config for materialized views (so upgrading grupr does not cause a huge behaviour change)
- Fail when encountering out-of-database grant to database role (which atm should not be possible in Snowflake)
- Correct logic working with unmanaged grants (we can't parse SHOW GRANTS records fully for object types we do not manage)
- Streamline logic of various 'set grants' methods: logic on positive matches of grants we should keep; and add all other grants as candidates for being revoked. Caught and fixed a few nasty value semantics errors.
- Clarify in comments and documentation how grupr only matches objects in STANDARD databases; and why you can grant database roles in upstream shares to product dtap roles: grupr will ignore such grants as unmanaged. This is the case even if you grant IMPORTED PRIVILEGES to a product role: since grupr does not manage such grants directly for product roles, it will leave them intact (grupr manages read privileges like SELECT on behalf of database roles it created for products).
- Improve parsing of output of SHOW FUTURE GRANTS
- Improve parsing of output of SHOW GRANTS (in particular, do not fail when encountering unmanaged grants)
- Use SHOW TABLES and SHOW VIEWS rather than SHOW OBJECTS to query objects in schemas, to more easily identify materialized views.
- Only grant CREATE DATABASE ROLE on databases where the grupr role does not have this privilege yet